### PR TITLE
Update mac CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,11 +278,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macOS-13
-            target: x86_64-apple-darwin
-          - os: macOS-latest
-            target: aarch64-apple-darwin
-    runs-on: ${{ matrix.os }}
+            - target: x86_64-apple-darwin
+            - target: aarch64-apple-darwin
+    runs-on: macos-latest
     needs: [check-macos]
     env:
       ZNG_TP_LICENSES: true
@@ -314,6 +312,8 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
+        with:
+          targets: ${{ matrix.target }}
       - name: install cargo-about
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
         uses: baptiste0928/cargo-install@v3
@@ -325,7 +325,7 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
         env:
           SYSTEM_DEPS_LINK: static
-        run: cargo do prebuild --features image_avif
+        run: cargo do prebuild --features image_avif --target ${{ matrix.target }}
       - run: cargo clean
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
       - name: upload prebuilt
@@ -462,15 +462,7 @@ jobs:
       - run: cargo clean
         if: ${{ github.event.inputs.skip_tests != 'true' }}
   test-macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macOS-13
-            target: x86_64-apple-darwin
-          - os: macOS-latest
-            target: aarch64-apple-darwin
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     needs: [prebuild-macos]
     steps:
       - uses: dtolnay/rust-toolchain@stable
@@ -488,7 +480,7 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' }}
         uses: actions/download-artifact@v4
         with:
-          name: libzng_view.${{ matrix.target }}.dylib
+          name: libzng_view.aarch64-apple-darwin.dylib
           path: crates/zng-view-prebuilt/lib
       - run: cargo do test --nextest
         if: ${{ github.event.inputs.skip_tests != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,12 +274,6 @@ jobs:
           path: crates/zng-view-prebuilt/lib/zng_view.${{ matrix.target }}.dll
           if-no-files-found: error
   prebuild-macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-            - target: x86_64-apple-darwin
-            - target: aarch64-apple-darwin
     runs-on: macos-latest
     needs: [check-macos]
     env:
@@ -312,8 +306,6 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
-        with:
-          targets: ${{ matrix.target }}
       - name: install cargo-about
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
         uses: baptiste0928/cargo-install@v3
@@ -325,15 +317,46 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
         env:
           SYSTEM_DEPS_LINK: static
-        run: cargo do prebuild --features image_avif --target ${{ matrix.target }}
+        run: cargo do prebuild --features image_avif
       - run: cargo clean
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
       - name: upload prebuilt
         if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: libzng_view.${{ matrix.target }}.dylib
-          path: crates/zng-view-prebuilt/lib/libzng_view.${{ matrix.target }}.dylib
+          name: libzng_view.aarch64-apple-darwin.dylib
+          path: crates/zng-view-prebuilt/lib/libzng_view.aarch64-apple-darwin.dylib
+          if-no-files-found: error
+  prebuild-macos-x86:
+    runs-on: macos-latest
+    needs: [check-macos]
+    env:
+      ZNG_TP_LICENSES: true
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
+      - uses: dtolnay/rust-toolchain@stable
+        if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
+        with:
+          targets: x86_64-apple-darwin
+      - name: install cargo-about
+        if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-about
+      - name: cargo do prebuild --target x86_64-apple-darwin
+        if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
+        env:
+          SYSTEM_DEPS_LINK: static
+        run: cargo do prebuild --target x86_64-apple-darwin
+      - run: cargo clean
+        if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
+      - name: upload prebuilt
+        if: ${{ github.event.inputs.skip_tests != 'true' || github.event.inputs.skip_release != 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: libzng_view.x86_64-apple-darwin.dylib
+          path: crates/zng-view-prebuilt/lib/libzng_view.x86_64-apple-darwin.dylib
           if-no-files-found: error
 
   doc-ubuntu:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* x86_64-apple-darwin prebuilt view-process is now cross-compiled from the Github ARM runner.
+    - Removed support for AVIF images in the prebuilt for this target.
+    - Follow the `docs/avif-setup.md` guide to build view-process with AVIF support.
 
 # 0.16.1
 


### PR DESCRIPTION
Github will remove mac-13, now cross compiles to continue support x86 prebuild

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->