### PR TITLE
Fix ZOOM_TO_FIT_CMD impl

### DIFF
--- a/crates/zng-wgt-scroll/src/node.rs
+++ b/crates/zng-wgt-scroll/src/node.rs
@@ -560,7 +560,7 @@ pub fn zoom_commands_node(child: impl IntoUiNode) -> UiNode {
     fn fit_scale() -> Factor {
         let scroll = WIDGET.info().scroll_info().unwrap();
         let viewport = (scroll.viewport_size() + scroll.joiner_size()).to_f32(); // viewport without scrollbars
-        let content = scroll.content().size.to_f32() / scroll.zoom_scale();
+        let content = scroll.content().size.max(PxSize::splat(Px(1))).to_f32() / scroll.zoom_scale();
         (viewport.width / content.width).min(viewport.height / content.height).fct()
     }
 


### PR DESCRIPTION
Zero sized contents caused scale to become max

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->