### PR TITLE
Fix buttons at the top-level of `Menu!` not returning focus on click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix buttons at the top-level of `Menu!` not returning focus on click.
 * View-process now tries to guess image format in case of header decode error for an extension or mime defined format.
 
 # 0.17.0

--- a/crates/zng-wgt-menu/src/lib.rs
+++ b/crates/zng-wgt-menu/src/lib.rs
@@ -16,7 +16,7 @@ use zng_wgt::{base_color, margin, prelude::*};
 use zng_wgt_access::{AccessRole, access_role};
 use zng_wgt_button::BUTTON;
 use zng_wgt_container::{child_end, padding};
-use zng_wgt_input::focus::alt_focus_scope;
+use zng_wgt_input::focus::{FocusClickBehavior, alt_focus_scope, focus_click_behavior};
 use zng_wgt_style::{Style, StyleMix, impl_style_fn, style_fn};
 
 pub mod context;
@@ -121,6 +121,7 @@ impl ButtonStyle {
             padding = 4;
 
             access_role = AccessRole::MenuItem;
+            focus_click_behavior = FocusClickBehavior::ExitEnabled;
 
             zng_wgt_container::child_start =
                 BUTTON
@@ -150,6 +151,7 @@ impl IconButtonStyle {
             padding = 4;
 
             access_role = AccessRole::MenuItem;
+            focus_click_behavior = FocusClickBehavior::ExitEnabled;
 
             zng_wgt_container::child =
                 BUTTON
@@ -203,6 +205,7 @@ impl ToggleStyle {
             self;
             padding = 4;
             access_role = AccessRole::MenuItem;
+            focus_click_behavior = FocusClickBehavior::ExitEnabled;
         }
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->