### PR TITLE
Fix panic in some filters

### DIFF
--- a/crates/zng-wgt-filter/Cargo.toml
+++ b/crates/zng-wgt-filter/Cargo.toml
@@ -14,3 +14,4 @@ keywords = ["gui", "ui", "user-interface", "zng"]
 [dependencies]
 zng-wgt = { path = "../zng-wgt", version = "0.10.2", default-features = false }
 zng-color = { path = "../zng-color", version = "0.8.2", default-features = false }
+tracing =  { version = "0.1", default-features = false }


### PR DESCRIPTION
Filters that depend on layout panic if rendered before layout. It is an error to render before layout, but the correct way to handle this is just log an error and ignore.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->