### PR TITLE
Rollup of small breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This release contains breaking changes that affect the advanced event handler an
 
     To migrate app handlers remove `app_` prefix with normal. To migrate custom event property declarations replace `impl WidgetHandler<A>` with `Handler<A>` and execute the async task is needed. Other use cases will continue working, you can now omit the args type in most handlers. 
 
+* **Breaking** `Length` and `LengthExpr` are now `non_exhaustive`.
+
 * **Breaking** Rename *logo* to *super* in `ModifiersState`. This was missed in a previous breaking refactor.
 
 * Detect and recover from view-process not responding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This release contains breaking changes that affect the advanced event handler an
 
     To migrate app handlers remove `app_` prefix with normal. To migrate custom event property declarations replace `impl WidgetHandler<A>` with `Handler<A>` and execute the async task is needed. Other use cases will continue working, you can now omit the args type in most handlers. 
 
+* **Breaking** Rename *logo* to *super* in `ModifiersState`. This was missed in a previous breaking refactor.
+
 * Detect and recover from view-process not responding.
     - **Breaking** Added `Api::ping` and related items to the view-process API.
     - Only breaking for custom view-process implementers.

--- a/crates/zng-app-proc-macros/src/property.rs
+++ b/crates/zng-app-proc-macros/src/property.rs
@@ -669,7 +669,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> 
                     self.ext_property_unset__(#ident_meta {}.id())
                 }
 
-                #[doc(hidden)]
+                #(#docs)*
                 fn #ident_sorted #impl_gens(&mut self, #(#sorted_idents: #sorted_tys),*) #where_gens {
                     let args = #ident_meta { }.args_sorted(#(#sorted_idents),*);
                     self.ext_property__(args)

--- a/crates/zng-app/src/shortcut.rs
+++ b/crates/zng-app/src/shortcut.rs
@@ -306,7 +306,7 @@ impl ModifierGesture {
     /// To modifiers state.
     pub fn modifiers_state(&self) -> ModifiersState {
         match self {
-            ModifierGesture::Super => ModifiersState::LOGO,
+            ModifierGesture::Super => ModifiersState::SUPER,
             ModifierGesture::Ctrl => ModifiersState::CTRL,
             ModifierGesture::Shift => ModifiersState::SHIFT,
             ModifierGesture::Alt => ModifiersState::ALT,
@@ -588,7 +588,7 @@ bitflags! {
         /// Any "logo" key.
         ///
         /// This is the "windows" key on PC and "command" key on Mac.
-        const LOGO = 0b1100_0000; // TODO(breaking) rename to SUPER
+        const SUPER = 0b1100_0000;
     }
 }
 impl ModifiersState {
@@ -606,7 +606,7 @@ impl ModifiersState {
     }
     /// Returns `true` if any logo key is pressed.
     pub fn has_super(self) -> bool {
-        self.intersects(Self::LOGO)
+        self.intersects(Self::SUPER)
     }
 
     /// Returns `true` if only any flag in `part` is pressed.
@@ -627,8 +627,8 @@ impl ModifiersState {
         self.is_only(ModifiersState::ALT)
     }
     /// Returns `true` if only any logo key is pressed.
-    pub fn is_only_logo(self) -> bool {
-        self.is_only(ModifiersState::LOGO)
+    pub fn is_only_super(self) -> bool {
+        self.is_only(ModifiersState::SUPER)
     }
 
     /// Removes `part` and returns if it was removed.
@@ -655,9 +655,9 @@ impl ModifiersState {
         self.take(ModifiersState::ALT)
     }
 
-    /// Removes `LOGO` and returns if it was removed.
-    pub fn take_logo(&mut self) -> bool {
-        self.take(ModifiersState::LOGO)
+    /// Removes `SUPER` and returns if it was removed.
+    pub fn take_super(&mut self) -> bool {
+        self.take(ModifiersState::SUPER)
     }
 
     /// Returns modifiers that set both left and right flags if any side is set in `self`.
@@ -673,7 +673,7 @@ impl ModifiersState {
             r |= Self::SHIFT;
         }
         if self.has_super() {
-            r |= Self::LOGO;
+            r |= Self::SUPER;
         }
         r
     }
@@ -694,8 +694,8 @@ impl ModifiersState {
     }
 
     /// Returns only the logo flags in `self`.
-    pub fn into_logo(self) -> Self {
-        self & Self::LOGO
+    pub fn into_super(self) -> Self {
+        self & Self::SUPER
     }
 
     /// Modifier from `code`, returns empty if the key is not a modifier.
@@ -720,14 +720,14 @@ impl ModifiersState {
             Key::AltGraph => Self::R_ALT,
             Key::Shift => Self::SHIFT,
             Key::Ctrl => Self::CTRL,
-            Key::Super => Self::LOGO,
+            Key::Super => Self::SUPER,
             _ => Self::empty(),
         }
     }
 
     /// All key codes that when pressed form the modifiers state.
     ///
-    /// In case of multiple keys the order is `LOGO`, `CTRL`, `SHIFT`, `ALT`.
+    /// In case of multiple keys the order is `SUPER`, `CTRL`, `SHIFT`, `ALT`.
     ///
     /// In case both left and right keys are flagged for a modifier, the left key is used.
     pub fn codes(self) -> Vec<KeyCode> {
@@ -762,11 +762,11 @@ impl ModifiersState {
 
     /// All keys that when pressed form the modifiers state.
     ///
-    /// In case of multiple keys the order is `LOGO`, `CTRL`, `SHIFT`, `ALT`.
+    /// In case of multiple keys the order is `SUPER`, `CTRL`, `SHIFT`, `ALT`.
     pub fn keys(self) -> Vec<Key> {
         let mut r = vec![];
 
-        if self.intersects(Self::LOGO) {
+        if self.intersects(Self::SUPER) {
             r.push(Key::Super);
         }
 

--- a/crates/zng-layout/src/unit/length.rs
+++ b/crates/zng-layout/src/unit/length.rs
@@ -28,7 +28,8 @@ pub use expr::*;
 /// * `Dip` and `px` lengths uses [`Dip`] and [`Px`] equality.
 /// * `Relative`, `Em`, `RootEm` lengths use the [`Factor`] equality.
 /// * Viewport lengths uses [`about_eq`] with `0.00001` granularity.
-#[derive(Clone, serde::Serialize, serde::Deserialize)] // TODO(breaking) non_exhaustive
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub enum Length {
     /// The default (initial) value.
     Default,

--- a/crates/zng-layout/src/unit/length/expr.rs
+++ b/crates/zng-layout/src/unit/length/expr.rs
@@ -9,7 +9,8 @@ use crate::{
 };
 
 /// Represents an unresolved [`Length`] expression.
-#[derive(Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)] // TODO(breaking) non_exhaustive
+#[derive(Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub enum LengthExpr {
     /// Sums the both layout length.
     Add(Length, Length),

--- a/crates/zng-wgt-input/src/focus.rs
+++ b/crates/zng-wgt-input/src/focus.rs
@@ -312,7 +312,7 @@ event_property! {
 /// [`is_focus_within`]: fn@is_focus_within
 /// [`is_focused_hgl`]: fn@is_focused_hgl
 /// [`is_return_focus`]: fn@is_return_focus
-#[property(CONTEXT, widget_impl(FocusableMix<P>))] // TODO(breaking) move this to EVENT?
+#[property(EVENT, widget_impl(FocusableMix<P>))]
 pub fn is_focused(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
     event_state(child, state, false, FOCUS_CHANGED_EVENT, |args| {
         let id = WIDGET.id();
@@ -334,7 +334,7 @@ pub fn is_focused(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
 ///
 /// [`is_focused`]: fn@is_focused
 /// [`is_focus_within_hgl`]: fn@is_focus_within_hgl
-#[property(CONTEXT, widget_impl(FocusableMix<P>))]
+#[property(EVENT, widget_impl(FocusableMix<P>))]
 pub fn is_focus_within(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
     event_state(child, state, false, FOCUS_CHANGED_EVENT, |args| {
         let id = WIDGET.id();
@@ -360,7 +360,7 @@ pub fn is_focus_within(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiN
 ///
 /// [`is_focus_within_hgl`]: fn@is_focus_within_hgl
 /// [`is_focused`]: fn@is_focused
-#[property(CONTEXT, widget_impl(FocusableMix<P>))]
+#[property(EVENT, widget_impl(FocusableMix<P>))]
 pub fn is_focused_hgl(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
     event_state(child, state, false, FOCUS_CHANGED_EVENT, |args| {
         let id = WIDGET.id();
@@ -384,7 +384,7 @@ pub fn is_focused_hgl(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNo
 ///
 /// [`is_focused_hgl`]: fn@is_focused_hgl
 /// [`is_focus_within`]: fn@is_focus_within
-#[property(CONTEXT, widget_impl(FocusableMix<P>))]
+#[property(EVENT, widget_impl(FocusableMix<P>))]
 pub fn is_focus_within_hgl(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
     event_state(child, state, false, FOCUS_CHANGED_EVENT, |args| {
         let id = WIDGET.id();
@@ -416,7 +416,7 @@ pub fn is_focus_within_hgl(child: impl IntoUiNode, state: impl IntoVar<bool>) ->
 ///
 /// [`is_focused`]: fn@is_focused_hgl
 /// [`is_focused_hgl`]: fn@is_focused_hgl
-#[property(CONTEXT, widget_impl(FocusableMix<P>))]
+#[property(EVENT, widget_impl(FocusableMix<P>))]
 pub fn is_return_focus(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
     event_state(child, state, false, RETURN_FOCUS_CHANGED_EVENT, |args| {
         let id = WIDGET.id();
@@ -435,7 +435,7 @@ pub fn is_return_focus(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiN
 /// To check if only the widget is the return focus use [`is_return_focus`].
 ///
 /// [`is_return_focus`]: fn@is_return_focus
-#[property(CONTEXT, widget_impl(FocusableMix<P>))]
+#[property(EVENT, widget_impl(FocusableMix<P>))]
 pub fn is_return_focus_within(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
     event_state(child, state, false, RETURN_FOCUS_CHANGED_EVENT, |args| {
         let id = WIDGET.id();
@@ -454,7 +454,7 @@ pub fn is_return_focus_within(child: impl IntoUiNode, state: impl IntoVar<bool>)
 /// When the widget is inited and present in the info tree a [`FOCUS.focus_widget_or_related`] request is made for the widget.
 ///
 /// [`FOCUS.focus_widget_or_related`]: FOCUS::focus_widget_or_related
-#[property(CONTEXT, default(false), widget_impl(FocusableMix<P>))]
+#[property(EVENT, default(false), widget_impl(FocusableMix<P>))]
 pub fn focus_on_init(child: impl IntoUiNode, enabled: impl IntoVar<bool>) -> UiNode {
     let enabled = enabled.into_var();
 
@@ -499,7 +499,7 @@ pub fn focus_on_init(child: impl IntoUiNode, enabled: impl IntoVar<bool>) -> UiN
 ///
 /// [`modal`]: fn@zng_wgt::modal
 /// [`focus_click_behavior`]: fn@focus_click_behavior
-#[property(CONTEXT, default(false), widget_impl(FocusableMix<P>))]
+#[property(EVENT, default(false), widget_impl(FocusableMix<P>))]
 pub fn return_focus_on_deinit(child: impl IntoUiNode, enabled: impl IntoVar<bool>) -> UiNode {
     let enabled = enabled.into_var();
     let mut return_focus = None;

--- a/crates/zng-wgt-undo-history/src/lib.rs
+++ b/crates/zng-wgt-undo-history/src/lib.rs
@@ -370,12 +370,12 @@ impl UndoPanelArgs {
 /// Menu style button for an entry in a undo/redo stack.
 #[widget($crate::UndoRedoButtonStyle)]
 pub struct UndoRedoButtonStyle(Style);
-impl_named_style_fn!(undo_button, UndoRedoButtonStyle); // TODO(breaking) rename to undo_redo
+impl_named_style_fn!(undo_redo_button, UndoRedoButtonStyle);
 impl UndoRedoButtonStyle {
     fn widget_intrinsic(&mut self) {
         widget_set! {
             self;
-            named_style_fn = UNDO_BUTTON_STYLE_FN_VAR;
+            named_style_fn = UNDO_REDO_BUTTON_STYLE_FN_VAR;
             padding = 4;
             child_align = Align::START;
 

--- a/crates/zng-wgt-undo-history/src/lib.rs
+++ b/crates/zng-wgt-undo-history/src/lib.rs
@@ -65,11 +65,11 @@ context_var! {
 
 /// Widget function that converts [`UndoEntryArgs`] to widgets.
 ///
-/// Try [`undo_button_style_fn`] for making only visual changes.
+/// Try [`undo_redo_button_style_fn`] for making only visual changes.
 ///
 /// Sets the [`UNDO_ENTRY_FN_VAR`].
 ///
-/// [`undo_button_style_fn`]: fn@undo_button_style_fn
+/// [`undo_redo_button_style_fn`]: fn@undo_redo_button_style_fn
 #[property(CONTEXT+1, default(UNDO_ENTRY_FN_VAR), widget_impl(UndoHistory))]
 pub fn undo_entry_fn(child: impl IntoUiNode, wgt_fn: impl IntoVar<WidgetFn<UndoEntryArgs>>) -> UiNode {
     with_context_var(child, UNDO_ENTRY_FN_VAR, wgt_fn)
@@ -109,7 +109,7 @@ pub fn op(op: impl IntoValue<UndoOp>) {}
 
 /// Default [`UNDO_ENTRY_FN_VAR`].
 ///
-/// Returns a `Button!` with the [`UNDO_BUTTON_STYLE_FN_VAR`] and the entry displayed in a `Text!` child.
+/// Returns a `Button!` with the [`UNDO_REDO_BUTTON_STYLE_FN_VAR`] and the entry displayed in a `Text!` child.
 /// The button notifies [`UNDO_CMD`] or [`REDO_CMD`] with the entry timestamp, the command is scoped on the
 /// undo parent of the caller not of the button.
 ///

--- a/crates/zng/src/handler.rs
+++ b/crates/zng/src/handler.rs
@@ -57,6 +57,7 @@
 //! ```
 //! # use zng::prelude::*;
 //! # use zng::focus::FOCUS_CHANGED_EVENT;
+//! # fn example() {
 //! FOCUS_CHANGED_EVENT
 //!     .on_pre_event(hn!(|args| {
 //!         println!("focused: {:?}", args.new_focus);
@@ -65,6 +66,7 @@
 //!         }
 //!     }))
 //!     .perm();
+//! # }
 //! ```
 //!
 //! In the example above the event subscription is made `perm`, but inside the handler `unsubscribe` is called when a

--- a/crates/zng/src/handler.rs
+++ b/crates/zng/src/handler.rs
@@ -49,14 +49,40 @@
 //! # ; }
 //! ```
 //!
-//! App Context
+//! # App Context
 //!
-//! When a handler is not set in a widget the [`APP_HANDLER`] contextual service is available !!: TODO docs
+//! When a handler is not set in a widget the [`APP_HANDLER`] contextual service is available, it can be used to unsubscribe
+//! the event from within.
 //!
-//! Args Type Inference
+//! ```
+//! # use zng::prelude::*;
+//! # use zng::focus::FOCUS_CHANGED_EVENT;
+//! FOCUS_CHANGED_EVENT
+//!     .on_pre_event(hn!(|args| {
+//!         println!("focused: {:?}", args.new_focus);
+//!         if args.new_focus.is_none() {
+//!             zng::handler::APP_HANDLER.unsubscribe();
+//!         }
+//!     }))
+//!     .perm();
+//! ```
 //!
-//! The [`Handler<A>`] type is an alias for `Box<dyn FnMut(&A) ...>` by necessity as this is the only way to have a type where
-//! the closure args is inferred. !!: TODO limitations
+//! In the example above the event subscription is made `perm`, but inside the handler `unsubscribe` is called when a
+//! condition is met, causing the handler to be dropped. This is a common pattern for app level event handlers that
+//! can manage their own subscription.
+//!
+//! The [`APP_HANDLER`] will also be available after each `await` point in async handlers, after an async task unsubscribes
+//! all running handler tasks will run to the end and no new tasks will be started.
+//!
+//! # Args Type Inference
+//!
+//! The [`Handler<A>`] type is an alias for `Box<dyn FnMut(&A + Clone + 'static) ...>` by necessity as this is the only way to have a type where
+//! the closure args is inferred. Unfortunately this has some limitations, documentation shows the raw box type, the `A` bounds is not enforced
+//! on type declaration too.
+//!
+//! These limitations enable type inference for the arguments of [`hn!`] and [`async_hn!`] set directly on a property, reducing the need to
+//! track down exact event args types, unfortunately as of this release the [`hn_once!`] and [`async_hn_once!`] handlers will still need
+//! and explicit args type if the handler uses the arg.
 //!
 //! [`WIDGET`]: crate::widget::WIDGET
 //! [`clmv!`]: crate::clmv

--- a/crates/zng/src/undo.rs
+++ b/crates/zng/src/undo.rs
@@ -69,6 +69,6 @@ pub use zng_wgt_undo::{UndoMix, undo_enabled, undo_interval, undo_limit, undo_sc
 pub mod history {
     pub use zng_wgt_undo_history::{
         UndoEntryArgs, UndoHistory, UndoPanelArgs, UndoRedoButtonStyle, UndoStackArgs, group_by_undo_interval, is_cap_hovered_timestamp,
-        undo_button_style_fn,
+        undo_redo_button_style_fn,
     };
 }


### PR DESCRIPTION
* `Length` and `LengthExpr` are now `non_exhaustive`.
* Rename *logo* to *super* in `ModifiersState`.
* Optimize when_var builder.
* Some doc fixes.