### PR TITLE
Rename old "property build action" to "property attributes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-This release contains breaking changes that affect the advanced event handler and view-process APIs.
+This release contains breaking changes that affect the advanced event handler, capture-only properties and view-process APIs.
 
 * Refactor handlers to enable args type inference.
     - Added unified `Handler<A>` type.
@@ -15,6 +15,7 @@ This release contains breaking changes that affect the advanced event handler an
     - Properties that modify the widget build, with the same access level as a widget build action.
     - `#[property]` now accepts functions with signature `fn(&mut WidgetBuilding, ...)`.
     - **Breaking** Removed `capture` from `#[property]`, migrate to an empty mixin property.
+    - **Breaking** Renamed old "property build action" to "property attributes". This is a more accurate name and avoids confusion.
 
 * Refactor how the default style is declared.
     - **Breaking** Removed `style_base_fn`.

--- a/crates/zng-app-proc-macros/src/property.rs
+++ b/crates/zng-app-proc-macros/src/property.rs
@@ -255,7 +255,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> 
                         }
                     });
                     input_new_dyn.push(quote! {
-                        let __actions__ = #core::widget::builder::iter_input_build_actions(&__args__.build_actions, &__args__.build_actions_when_data, #i);
+                        let __actions__ = #core::widget::builder::iter_input_attributes(&__args__.attributes, &__args__.attributes_when_data, #i);
                         #core::widget::builder::new_dyn_var(&mut __inputs__, __actions__)
                     });
                     let get_ident = ident!("__w_{ident}__");
@@ -288,7 +288,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> 
                         std::clone::Clone::clone(&self.#ident),
                     });
                     input_new_dyn.push(quote! {
-                        let __actions__ = #core::widget::builder::iter_input_build_actions(&__args__.build_actions, &__args__.build_actions_when_data, #i);
+                        let __actions__ = #core::widget::builder::iter_input_attributes(&__args__.attributes, &__args__.attributes_when_data, #i);
                         #core::widget::builder::new_dyn_other(&mut __inputs__, __actions__)
                     });
                     let get_ident = ident!("__w_{ident}__");
@@ -321,7 +321,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> 
                         self.#ident.take_on_init(),
                     });
                     input_new_dyn.push(quote! {
-                        let __actions__ = #core::widget::builder::iter_input_build_actions(&__args__.build_actions, &__args__.build_actions_when_data, #i);
+                        let __actions__ = #core::widget::builder::iter_input_attributes(&__args__.attributes, &__args__.attributes_when_data, #i);
                         #core::widget::builder::new_dyn_ui_node(&mut __inputs__, __actions__)
                     });
                     let get_ident = ident!("__w_{ident}__");
@@ -354,7 +354,7 @@ pub fn expand(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> 
                         self.#ident.handler(),
                     });
                     input_new_dyn.push(quote! {
-                        let __actions__ = #core::widget::builder::iter_input_build_actions(&__args__.build_actions, &__args__.build_actions_when_data, #i);
+                        let __actions__ = #core::widget::builder::iter_input_attributes(&__args__.attributes, &__args__.attributes_when_data, #i);
                         #core::widget::builder::new_dyn_handler(&mut __inputs__, __actions__)
                     });
                     let get_ident = ident!("__w_{ident}__");

--- a/crates/zng-app-proc-macros/src/wgt_property_attrs.rs
+++ b/crates/zng-app-proc-macros/src/wgt_property_attrs.rs
@@ -62,7 +62,7 @@ pub(crate) fn expand_easing(args: proc_macro::TokenStream, input: proc_macro::To
                     }),
                 );
                 let id__ = #property_meta.id();
-                #core::widget::base::WidgetImpl::base(&mut *#builder).push_when_build_action_data__(
+                #core::widget::base::WidgetImpl::base(&mut *#builder).push_when_property_attribute_data__(
                     id__,
                     #name,
                     __data__,
@@ -79,7 +79,7 @@ pub(crate) fn expand_easing(args: proc_macro::TokenStream, input: proc_macro::To
                 #property_meta.input_types()
             );
             let id__ = #property_meta.id();
-            #core::widget::base::WidgetImpl::base(&mut *#builder).push_unset_property_build_action__(
+            #core::widget::base::WidgetImpl::base(&mut *#builder).push_unset_property_attribute__(
                 id__,
                 #name,
             );
@@ -101,7 +101,7 @@ pub(crate) fn expand_easing(args: proc_macro::TokenStream, input: proc_macro::To
                 );
                 if !__actions__.is_empty() {
                     let id__ = #property_meta.id();
-                    #core::widget::base::WidgetImpl::base(&mut *#builder).push_property_build_action__(
+                    #core::widget::base::WidgetImpl::base(&mut *#builder).push_property_attribute__(
                         id__,
                         #name,
                         __actions__

--- a/crates/zng-app/src/lib.rs
+++ b/crates/zng-app/src/lib.rs
@@ -103,7 +103,7 @@ pub mod __proc_macro_util {
             pub use crate::widget::builder::{
                 AnyArcHandler, HandlerInWhenExprError, Importance, InputKind, PropertyArgs, PropertyId, PropertyInfo, PropertyInput,
                 PropertyInputTypes, PropertyNewArgs, SourceLocation, UiNodeInWhenExprError, WgtInfo, WhenInput, WhenInputMember,
-                WhenInputVar, WidgetBuilding, WidgetType, handler_to_args, iter_input_build_actions, nest_group_items, new_dyn_handler,
+                WhenInputVar, WidgetBuilding, WidgetType, handler_to_args, iter_input_attributes, nest_group_items, new_dyn_handler,
                 new_dyn_other, new_dyn_ui_node, new_dyn_var, panic_input, ui_node_to_args, value_to_args, var_getter, var_state,
                 var_to_args,
             };

--- a/crates/zng-app/src/widget/base.rs
+++ b/crates/zng-app/src/widget/base.rs
@@ -10,7 +10,7 @@ use crate::{
 use super::{
     WIDGET,
     builder::{
-        AnyPropertyBuildAction, Importance, PropertyArgs, PropertyId, SourceLocation, WhenBuildAction, WhenInfo, WhenInput, WidgetBuilder,
+        AnyPropertyAttribute, Importance, PropertyArgs, PropertyId, SourceLocation, PropertyAttributeWhen, WhenInfo, WhenInput, WidgetBuilder,
         WidgetType,
     },
     node::{FillUiNode, UiNode, UiNodeOp},
@@ -99,7 +99,7 @@ impl WidgetBase {
             inputs,
             state,
             assigns: vec![],
-            build_action_data: vec![],
+            attributes_data: vec![],
             expr,
             location,
         });
@@ -154,43 +154,43 @@ impl WidgetBase {
     }
 
     #[doc(hidden)]
-    pub fn push_unset_property_build_action__(&mut self, property_id: PropertyId, action_name: &'static str) {
-        assert!(self.when.get_mut().is_none(), "cannot unset build actions in when assigns");
+    pub fn push_unset_property_attribute__(&mut self, property_id: PropertyId, attribute_name: &'static str) {
+        assert!(self.when.get_mut().is_none(), "cannot unset property attribute in when assigns");
 
         self.builder
             .get_mut()
             .as_mut()
-            .expect("cannot unset build actions after build")
-            .push_unset_property_build_action(property_id, action_name, self.importance);
+            .expect("cannot unset property attribute after build")
+            .push_unset_property_attribute(property_id, attribute_name, self.importance);
     }
 
     #[doc(hidden)]
-    pub fn push_property_build_action__(
+    pub fn push_property_attribute__(
         &mut self,
         property_id: PropertyId,
-        action_name: &'static str,
-        input_actions: Vec<Box<dyn AnyPropertyBuildAction>>,
+        attribute_name: &'static str,
+        input_actions: Vec<Box<dyn AnyPropertyAttribute>>,
     ) {
         assert!(
             self.when.get_mut().is_none(),
-            "cannot push property build action in `when`, use `push_when_build_action_data__`"
+            "cannot push property attribute in `when`, use `push_when_property_attribute_data__`"
         );
 
         self.builder
             .get_mut()
             .as_mut()
-            .expect("cannot unset build actions after build")
-            .push_property_build_action(property_id, action_name, self.importance, input_actions);
+            .expect("cannot set property attributes after build")
+            .push_property_attribute(property_id, attribute_name, self.importance, input_actions);
     }
 
     #[doc(hidden)]
-    pub fn push_when_build_action_data__(&mut self, property_id: PropertyId, action_name: &'static str, data: WhenBuildAction) {
+    pub fn push_when_property_attribute_data__(&mut self, property_id: PropertyId, attribute_name: &'static str, data: PropertyAttributeWhen) {
         let when = self
             .when
             .get_mut()
             .as_mut()
-            .expect("cannot push when build action data outside when blocks");
-        when.build_action_data.push(((property_id, action_name), data));
+            .expect("cannot push when property attribute data outside when blocks");
+        when.attributes_data.push(((property_id, attribute_name), data));
     }
 }
 
@@ -380,23 +380,23 @@ impl NonWidgetBase {
     }
 
     #[doc(hidden)]
-    pub fn push_unset_property_build_action__(&mut self, property_id: PropertyId, action_name: &'static str) {
-        self.base.push_unset_property_build_action__(property_id, action_name)
+    pub fn push_unset_property_attribute__(&mut self, property_id: PropertyId, action_name: &'static str) {
+        self.base.push_unset_property_attribute__(property_id, action_name)
     }
 
     #[doc(hidden)]
-    pub fn push_property_build_action__(
+    pub fn push_property_attribute__(
         &mut self,
         property_id: PropertyId,
         action_name: &'static str,
-        input_actions: Vec<Box<dyn AnyPropertyBuildAction>>,
+        input_actions: Vec<Box<dyn AnyPropertyAttribute>>,
     ) {
-        self.base.push_property_build_action__(property_id, action_name, input_actions)
+        self.base.push_property_attribute__(property_id, action_name, input_actions)
     }
 
     #[doc(hidden)]
-    pub fn push_when_build_action_data__(&mut self, property_id: PropertyId, action_name: &'static str, data: WhenBuildAction) {
-        self.base.push_when_build_action_data__(property_id, action_name, data)
+    pub fn push_when_property_attribute_data__(&mut self, property_id: PropertyId, action_name: &'static str, data: PropertyAttributeWhen) {
+        self.base.push_when_property_attribute_data__(property_id, action_name, data)
     }
 }
 impl WidgetImpl for NonWidgetBase {

--- a/crates/zng-app/src/widget/base.rs
+++ b/crates/zng-app/src/widget/base.rs
@@ -10,8 +10,8 @@ use crate::{
 use super::{
     WIDGET,
     builder::{
-        AnyPropertyAttribute, Importance, PropertyArgs, PropertyId, SourceLocation, PropertyAttributeWhen, WhenInfo, WhenInput, WidgetBuilder,
-        WidgetType,
+        AnyPropertyAttribute, Importance, PropertyArgs, PropertyAttributeWhen, PropertyId, SourceLocation, WhenInfo, WhenInput,
+        WidgetBuilder, WidgetType,
     },
     node::{FillUiNode, UiNode, UiNodeOp},
 };
@@ -184,7 +184,12 @@ impl WidgetBase {
     }
 
     #[doc(hidden)]
-    pub fn push_when_property_attribute_data__(&mut self, property_id: PropertyId, attribute_name: &'static str, data: PropertyAttributeWhen) {
+    pub fn push_when_property_attribute_data__(
+        &mut self,
+        property_id: PropertyId,
+        attribute_name: &'static str,
+        data: PropertyAttributeWhen,
+    ) {
         let when = self
             .when
             .get_mut()

--- a/crates/zng-var/src/var_impl/when_var.rs
+++ b/crates/zng-var/src/var_impl/when_var.rs
@@ -229,7 +229,7 @@ impl<O: VarValue> WhenVarBuilder<O> {
     ///
     /// [`build`]: Self::build
     pub fn try_from_built(var: &Var<O>) -> Option<Self> {
-        // this is used by #[easing(_)] in PropertyBuildAction to modify widget properties
+        // this is used by #[easing(_)] in PropertyAttribute to modify widget properties
 
         let builder = AnyWhenVarBuilder::try_from_built(var)?;
         Some(Self { builder, _t: PhantomData })

--- a/crates/zng/src/widget.rs
+++ b/crates/zng/src/widget.rs
@@ -137,10 +137,10 @@ pub use zng_wgt_fill::{
 pub mod builder {
     pub use zng_app::widget::builder::{
         AnyWhenArcHandlerBuilder, BuilderProperty, BuilderPropertyMut, BuilderPropertyRef, Importance, InputKind, NestGroup, NestPosition,
-        PropertyArgs, PropertyBuildAction, PropertyBuildActionArgs, PropertyBuildActions, PropertyBuildActionsWhenData, PropertyId,
-        PropertyInfo, PropertyInput, PropertyInputTypes, PropertyNewArgs, SourceLocation, WhenBuildAction, WhenInfo, WhenInput,
-        WhenInputMember, WhenInputVar, WidgetBuilder, WidgetBuilderProperties, WidgetBuilding, WidgetType, property_args, property_id,
-        property_info, property_input_types, source_location, widget_type,
+        PropertyArgs, PropertyAttribute, PropertyAttributeArgs, PropertyAttributes, PropertyAttributesWhenData, PropertyId, PropertyInfo,
+        PropertyInput, PropertyInputTypes, PropertyNewArgs, SourceLocation, PropertyAttributeWhen, WhenInfo, WhenInput, WhenInputMember,
+        WhenInputVar, WidgetBuilder, WidgetBuilderProperties, WidgetBuilding, WidgetType, property_args, property_id, property_info,
+        property_input_types, source_location, widget_type,
     };
 }
 
@@ -534,7 +534,7 @@ pub use zng_app::widget::widget_mixin;
 
 /// Expands a property assign to include an easing animation.
 ///
-/// The attribute generates a [property build action] that applies [`Var::easing`] to the final variable inputs of the property.
+/// The attribute generates a [property attribute] that applies [`Var::easing`] to the final variable inputs of the property.
 ///
 /// # Arguments
 ///
@@ -551,7 +551,7 @@ pub use zng_app::widget::widget_mixin;
 /// [`TimeUnits`]: zng::layout::TimeUnits
 /// [`easing`]: mod@zng::var::animation::easing
 /// [`easing::linear`]: zng::var::animation::easing::linear
-/// [property build action]: crate::widget::builder::WidgetBuilder::push_property_build_action
+/// [property attribute]: crate::widget::builder::WidgetBuilder::push_property_attribute
 /// [`Var::easing`]: crate::var::Var::easing
 ///
 /// ## When

--- a/crates/zng/src/widget.rs
+++ b/crates/zng/src/widget.rs
@@ -137,8 +137,8 @@ pub use zng_wgt_fill::{
 pub mod builder {
     pub use zng_app::widget::builder::{
         AnyWhenArcHandlerBuilder, BuilderProperty, BuilderPropertyMut, BuilderPropertyRef, Importance, InputKind, NestGroup, NestPosition,
-        PropertyArgs, PropertyAttribute, PropertyAttributeArgs, PropertyAttributes, PropertyAttributesWhenData, PropertyId, PropertyInfo,
-        PropertyInput, PropertyInputTypes, PropertyNewArgs, SourceLocation, PropertyAttributeWhen, WhenInfo, WhenInput, WhenInputMember,
+        PropertyArgs, PropertyAttribute, PropertyAttributeArgs, PropertyAttributeWhen, PropertyAttributes, PropertyAttributesWhenData,
+        PropertyId, PropertyInfo, PropertyInput, PropertyInputTypes, PropertyNewArgs, SourceLocation, WhenInfo, WhenInput, WhenInputMember,
         WhenInputVar, WidgetBuilder, WidgetBuilderProperties, WidgetBuilding, WidgetType, property_args, property_id, property_info,
         property_input_types, source_location, widget_type,
     };


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->