### PR TITLE
Fix layout dependent on `LayoutMetrics::screen_ppi` not updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix layout dependent on `LayoutMetrics::screen_ppi` not updating on change.
 * Add `Var::flat_map_vec` for mapping `Var<Vec<T>>` to `Var<Vec<O>>` where `T` projects a `Var<O>`.
 * Default setting editor reset button is now localizable in the `zng-wgt-settings` l10n resources.
     - Also surface it in `zng::config::settings::editor::reset_button` for use in custom editors.

--- a/crates/zng-layout/src/context.rs
+++ b/crates/zng-layout/src/context.rs
@@ -599,6 +599,7 @@ impl LayoutMetrics {
     ///
     /// Default is `96.0`.
     pub fn screen_ppi(&self) -> Ppi {
+        LAYOUT.register_metrics_use(LayoutMask::SCREEN_PPI);
         self.s.screen_ppi
     }
 


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->