### PR TITLE
Replace docs logo image link

### DIFF
--- a/crates/cargo-zng/src/main.rs
+++ b/crates/cargo-zng/src/main.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Zng project management.
 //!

--- a/crates/zng-app-context/src/lib.rs
+++ b/crates/zng-app-context/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //! App execution context.
 //!
 //! # Crate

--- a/crates/zng-app-proc-macros/src/lib.rs
+++ b/crates/zng-app-proc-macros/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Proc-macros for `zng-app`.
 //!

--- a/crates/zng-app/src/lib.rs
+++ b/crates/zng-app/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! App process implementation.
 //!

--- a/crates/zng-clone-move/src/lib.rs
+++ b/crates/zng-clone-move/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Macros for declaring clone-move closures and async blocks.
 //!

--- a/crates/zng-color-proc-macros/src/lib.rs
+++ b/crates/zng-color-proc-macros/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Proc-macros for `zng-color`.
 //!

--- a/crates/zng-color/src/lib.rs
+++ b/crates/zng-color/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Color and gradient types, functions and macros, [`Rgba`], [`filter`], [`hex!`] and more.
 //!

--- a/crates/zng-env-proc-macros/src/lib.rs
+++ b/crates/zng-env-proc-macros/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Proc-macros for `zng-env`.
 //!

--- a/crates/zng-env/src/lib.rs
+++ b/crates/zng-env/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Process environment directories and unique name.
 //!

--- a/crates/zng-ext-clipboard/src/lib.rs
+++ b/crates/zng-ext-clipboard/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Clipboard app extension, service and commands.
 //!

--- a/crates/zng-ext-config/src/lib.rs
+++ b/crates/zng-ext-config/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Config service and sources.
 //!

--- a/crates/zng-ext-font/src/lib.rs
+++ b/crates/zng-ext-font/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Font loading, text segmenting and shaping.
 //!

--- a/crates/zng-ext-fs-watcher/src/lib.rs
+++ b/crates/zng-ext-fs-watcher/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! File system events and service.
 //!

--- a/crates/zng-ext-hot-reload-proc-macros/src/lib.rs
+++ b/crates/zng-ext-hot-reload-proc-macros/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Proc-macros for `zng-ext-hot-reload`.
 //!

--- a/crates/zng-ext-hot-reload/src/lib.rs
+++ b/crates/zng-ext-hot-reload/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Hot reload service.
 //!

--- a/crates/zng-ext-image/src/lib.rs
+++ b/crates/zng-ext-image/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Image loading and cache.
 //!

--- a/crates/zng-ext-input/src/lib.rs
+++ b/crates/zng-ext-input/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Input events and focused widget.
 //!

--- a/crates/zng-ext-l10n-proc-macros/src/lib.rs
+++ b/crates/zng-ext-l10n-proc-macros/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Proc-macros for `zng-ext-l10n`.
 //!

--- a/crates/zng-ext-l10n/src/lib.rs
+++ b/crates/zng-ext-l10n/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Localization service, [`l10n!`] and helpers.
 //!

--- a/crates/zng-ext-single-instance/src/lib.rs
+++ b/crates/zng-ext-single-instance/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Single app-process instance mode.
 //!

--- a/crates/zng-ext-svg/src/lib.rs
+++ b/crates/zng-ext-svg/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! SVG image support.
 //!

--- a/crates/zng-ext-undo/src/lib.rs
+++ b/crates/zng-ext-undo/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Undo-redo app extension, service and commands.
 //!

--- a/crates/zng-ext-window/src/lib.rs
+++ b/crates/zng-ext-window/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! App window and monitors manager.
 //!

--- a/crates/zng-handle/src/lib.rs
+++ b/crates/zng-handle/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Resource handle type.
 //!

--- a/crates/zng-layout/src/lib.rs
+++ b/crates/zng-layout/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Contextual layout units.
 //!

--- a/crates/zng-state-map/src/lib.rs
+++ b/crates/zng-state-map/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Hash-map of type erased values, useful for storing assorted dynamic state.
 //!

--- a/crates/zng-task-proc-macros/src/lib.rs
+++ b/crates/zng-task-proc-macros/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Proc-macros for `zng-task`.
 //!

--- a/crates/zng-task/src/lib.rs
+++ b/crates/zng-task/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Parallel async tasks and async task runners.
 //!

--- a/crates/zng-time/src/lib.rs
+++ b/crates/zng-time/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Configurable instant type and service.
 //!

--- a/crates/zng-tp-licenses/src/lib.rs
+++ b/crates/zng-tp-licenses/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Third party license management and collection.
 //!

--- a/crates/zng-txt/src/lib.rs
+++ b/crates/zng-txt/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! String type optimized for sharing.
 //!

--- a/crates/zng-unique-id/src/lib.rs
+++ b/crates/zng-unique-id/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Macros for generating unique ID types.
 //!

--- a/crates/zng-unit/src/lib.rs
+++ b/crates/zng-unit/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Base unit types.
 //!

--- a/crates/zng-var-proc-macros/src/lib.rs
+++ b/crates/zng-var-proc-macros/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Proc-macros for the `zng-var` crate.
 //!

--- a/crates/zng-var/src/lib.rs
+++ b/crates/zng-var/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Batch updated variables in an app context.
 //!

--- a/crates/zng-view-api/src/lib.rs
+++ b/crates/zng-view-api/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! The View Process API.
 //!

--- a/crates/zng-view-prebuilt/src/lib.rs
+++ b/crates/zng-view-prebuilt/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Dynamically links to [`zng-view`] pre-built library.
 //!

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! View-Process implementation.
 //!

--- a/crates/zng-wgt-access/src/lib.rs
+++ b/crates/zng-wgt-access/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //! Properties that define accessibility metadata.
 //!
 //! The properties in this crate should only be used by widget implementers, they only

--- a/crates/zng-wgt-ansi-text/src/lib.rs
+++ b/crates/zng-wgt-ansi-text/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! ANSI text widget, properties and nodes.
 //!

--- a/crates/zng-wgt-button/src/lib.rs
+++ b/crates/zng-wgt-button/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Button widget.
 //!

--- a/crates/zng-wgt-checkerboard/src/lib.rs
+++ b/crates/zng-wgt-checkerboard/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Checkerboard widget, properties and nodes.
 //!

--- a/crates/zng-wgt-container/src/lib.rs
+++ b/crates/zng-wgt-container/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Base container widget and properties.
 //!

--- a/crates/zng-wgt-data-view/src/lib.rs
+++ b/crates/zng-wgt-data-view/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Data view widget.
 //!

--- a/crates/zng-wgt-data/src/lib.rs
+++ b/crates/zng-wgt-data/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Contextual [`DATA`] and validation.
 //!

--- a/crates/zng-wgt-dialog/src/lib.rs
+++ b/crates/zng-wgt-dialog/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Dialog widget and service.
 //!

--- a/crates/zng-wgt-fill/src/lib.rs
+++ b/crates/zng-wgt-fill/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Properties that fill the widget inner bounds and nodes that fill the available space.
 //!

--- a/crates/zng-wgt-filter/src/lib.rs
+++ b/crates/zng-wgt-filter/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Color filter properties, [`opacity`](fn@opacity), [`filter`](fn@filter) and more.
 //!

--- a/crates/zng-wgt-grid/src/lib.rs
+++ b/crates/zng-wgt-grid/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Grid widgets, properties and nodes.
 //!

--- a/crates/zng-wgt-image/src/lib.rs
+++ b/crates/zng-wgt-image/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Image widget, properties and nodes.
 //!

--- a/crates/zng-wgt-input/src/lib.rs
+++ b/crates/zng-wgt-input/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Input events and focus properties.
 //!

--- a/crates/zng-wgt-inspector/src/lib.rs
+++ b/crates/zng-wgt-inspector/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Inspector, debug crash handler and debug properties.
 //!

--- a/crates/zng-wgt-layer/src/lib.rs
+++ b/crates/zng-wgt-layer/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Window layers and popup.
 //!

--- a/crates/zng-wgt-markdown/src/lib.rs
+++ b/crates/zng-wgt-markdown/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Markdown widget, properties and nodes.
 //!

--- a/crates/zng-wgt-material-icons/src/lib.rs
+++ b/crates/zng-wgt-material-icons/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Material icons for the [`Icon!`] widget.
 //!

--- a/crates/zng-wgt-menu/src/lib.rs
+++ b/crates/zng-wgt-menu/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Menu widgets and properties.
 //!

--- a/crates/zng-wgt-panel/src/lib.rs
+++ b/crates/zng-wgt-panel/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Panel widget and properties.
 //!

--- a/crates/zng-wgt-progress/src/lib.rs
+++ b/crates/zng-wgt-progress/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Progress indicator widget.
 //!

--- a/crates/zng-wgt-rule-line/src/lib.rs
+++ b/crates/zng-wgt-rule-line/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Rule line widgets.
 //!

--- a/crates/zng-wgt-scroll/src/lib.rs
+++ b/crates/zng-wgt-scroll/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Scroll widgets, properties and nodes.
 //!

--- a/crates/zng-wgt-settings/src/lib.rs
+++ b/crates/zng-wgt-settings/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //! Settings widgets.
 
 zng_wgt::enable_widget_macros!();

--- a/crates/zng-wgt-shortcut/src/lib.rs
+++ b/crates/zng-wgt-shortcut/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Shortcut display widget.
 //!

--- a/crates/zng-wgt-size-offset/src/lib.rs
+++ b/crates/zng-wgt-size-offset/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Exact size constraints and exact positioning properties.
 //!

--- a/crates/zng-wgt-slider/src/lib.rs
+++ b/crates/zng-wgt-slider/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Widget for selecting a value or range by dragging a selector thumb.
 //!

--- a/crates/zng-wgt-stack/src/lib.rs
+++ b/crates/zng-wgt-stack/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Stack widgets, properties and nodes.
 //!

--- a/crates/zng-wgt-style/src/lib.rs
+++ b/crates/zng-wgt-style/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Style building blocks.
 //!

--- a/crates/zng-wgt-text-input/src/lib.rs
+++ b/crates/zng-wgt-text-input/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Text input and label widgets.
 //!

--- a/crates/zng-wgt-text/src/lib.rs
+++ b/crates/zng-wgt-text/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Text widgets and properties.
 //!

--- a/crates/zng-wgt-toggle/src/lib.rs
+++ b/crates/zng-wgt-toggle/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Toggle widget, properties and commands.
 //!

--- a/crates/zng-wgt-tooltip/src/lib.rs
+++ b/crates/zng-wgt-tooltip/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Tooltip widget, properties and nodes.
 //!

--- a/crates/zng-wgt-transform/src/lib.rs
+++ b/crates/zng-wgt-transform/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Transform properties, [`scale`](fn@scale), [`rotate`](fn@rotate), [`transform`](fn@transform) and more.
 //!

--- a/crates/zng-wgt-undo-history/src/lib.rs
+++ b/crates/zng-wgt-undo-history/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Undo history widget.
 //!

--- a/crates/zng-wgt-undo/src/lib.rs
+++ b/crates/zng-wgt-undo/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Undo properties.
 //!

--- a/crates/zng-wgt-webrender-debug/src/lib.rs
+++ b/crates/zng-wgt-webrender-debug/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Webrender debug flags property for use with `zng-view` view-process.
 //!

--- a/crates/zng-wgt-window/src/lib.rs
+++ b/crates/zng-wgt-window/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Window widget, properties, properties and nodes.
 //!

--- a/crates/zng-wgt-wrap/src/lib.rs
+++ b/crates/zng-wgt-wrap/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Wrap panel, properties and nodes.
 //!

--- a/crates/zng-wgt/src/lib.rs
+++ b/crates/zng-wgt/src/lib.rs
@@ -1,5 +1,5 @@
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 //!
 //! Basic widget properties and helpers for declaring widgets and properties.
 //!

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -1,6 +1,6 @@
 #![expect(clippy::needless_doctest_main)]
-#![doc(html_favicon_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo-icon.png")]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/zng-ui/zng/main/examples/image/res/zng-logo.png")]
+#![doc(html_favicon_url = "https://zng-ui.github.io/res/zng-logo-icon.png")]
+#![doc(html_logo_url = "https://zng-ui.github.io/res/zng-logo.png")]
 
 //! Zng is a cross-platform GUI framework, it provides ready made highly customizable widgets, responsive layout,
 //! live data binding, easy localization, automatic focus navigation and accessibility, async and multi-threaded tasks, robust


### PR DESCRIPTION
Github is blocking hotlink to repository images, this replaces it with hotlink to github page image.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->