### PR TITLE
Allow multiple targets in `#[property]` arg `widget_impl`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,15 @@
     - Windows builds with default fonts now uses ~20MB less memory.
 
 * Inherit `StyleMix` for `Window` to facilitate theme implementation and live change.
+    - See `zng::window` documentation for theming tips.
+
 * Fix gradient stops with midway adjustment.
-* Replace `layout::Vector` add and sub implementations to be generic over any type that converts to vector.
+* Impl of `Add` and `Sub` for `layout::Vector` is now generic over any type that converts to vector.
 * Add `Var::chase_begin` to begin a deferred chase animation.
 * Add `zng::app::memory_profiler` for recording DHAT heap traces.
 * Add `zng::task::set_spawn_panic_handler` for apps to optionally handle panics in spawn and forget tasks.
 * Refactor `toggle::{select_on_init, deselect_on_deinit}` to ignore reinit (quick deinit/init).
+* `#[property]` argument `widget_impl` now accepts multiple widget targets.
 * Task worker process timeout is now configurable with ZNG_TASK_WORKER_TIMEOUT env var.
 * View process timeout is now configurable with ZNG_VIEW_TIMEOUT env var.
 * Fix view-process recover when it stops responding.

--- a/crates/zng-wgt-button/src/lib.rs
+++ b/crates/zng-wgt-button/src/lib.rs
@@ -274,7 +274,7 @@ pub fn cmd_param<T: VarValue>(child: impl IntoUiNode, cmd_param: impl IntoVar<T>
 ///
 /// [`cmd`]: fn@cmd
 /// [`child`]: fn@zng_wgt_container::child
-#[property(CONTEXT, default(CMD_CHILD_FN_VAR), widget_impl(Button))]
+#[property(CONTEXT, default(CMD_CHILD_FN_VAR), widget_impl(Button, DefaultStyle))]
 pub fn cmd_child_fn(child: impl IntoUiNode, cmd_child: impl IntoVar<WidgetFn<Command>>) -> UiNode {
     with_context_var(child, CMD_CHILD_FN_VAR, cmd_child)
 }
@@ -283,7 +283,7 @@ pub fn cmd_child_fn(child: impl IntoUiNode, cmd_child: impl IntoVar<WidgetFn<Com
 /// Sets the widget function used to produce the button tooltip when [`cmd`] is set and tooltip is not.
 ///
 /// [`cmd`]: fn@cmd
-#[property(CONTEXT, default(CMD_TOOLTIP_FN_VAR), widget_impl(Button))]
+#[property(CONTEXT, default(CMD_TOOLTIP_FN_VAR), widget_impl(Button, DefaultStyle))]
 pub fn cmd_tooltip_fn(child: impl IntoUiNode, cmd_tooltip: impl IntoVar<WidgetFn<CmdTooltipArgs>>) -> UiNode {
     with_context_var(child, CMD_TOOLTIP_FN_VAR, cmd_tooltip)
 }

--- a/crates/zng-wgt-dialog/src/lib.rs
+++ b/crates/zng-wgt-dialog/src/lib.rs
@@ -331,7 +331,7 @@ pub fn content(child: impl IntoUiNode, content: impl IntoUiNode) -> UiNode {
 }
 
 /// Dialog button generator.
-#[property(CONTEXT, default(BUTTON_FN_VAR), widget_impl(Dialog))]
+#[property(CONTEXT, default(BUTTON_FN_VAR), widget_impl(Dialog, DefaultStyle))]
 pub fn button_fn(child: impl IntoUiNode, button: impl IntoVar<WidgetFn<DialogButtonArgs>>) -> UiNode {
     with_context_var(child, BUTTON_FN_VAR, button)
 }

--- a/crates/zng-wgt-layer/src/popup.rs
+++ b/crates/zng-wgt-layer/src/popup.rs
@@ -473,7 +473,7 @@ fn setup_popup_close_service() {
 /// while awaiting the `delay`.
 ///
 /// [`is_close_delaying`]: fn@is_close_delaying
-#[property(EVENT, default(Duration::ZERO), widget_impl(Popup))]
+#[property(EVENT, default(Duration::ZERO), widget_impl(Popup, DefaultStyle))]
 pub fn close_delay(child: impl IntoUiNode, delay: impl IntoVar<Duration>) -> UiNode {
     let delay = delay.into_var();
     let mut timer = None::<DeadlineHandle>;
@@ -526,7 +526,7 @@ pub fn close_delay(child: impl IntoUiNode, delay: impl IntoVar<Duration>) -> UiN
 /// If close was requested for this layered widget and it is just awaiting for the [`close_delay`].
 ///
 /// [`close_delay`]: fn@close_delay
-#[property(EVENT+1, widget_impl(Popup))]
+#[property(EVENT+1, widget_impl(Popup, DefaultStyle))]
 pub fn is_close_delaying(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
     bind_state(child, IS_CLOSE_DELAYED_VAR, state)
 }

--- a/crates/zng-wgt-menu/src/context.rs
+++ b/crates/zng-wgt-menu/src/context.rs
@@ -172,7 +172,7 @@ context_var! {
 /// Widget function that generates the context menu layout.
 ///
 /// This property sets [`PANEL_FN_VAR`].
-#[property(CONTEXT, default(PANEL_FN_VAR), widget_impl(ContextMenu))]
+#[property(CONTEXT, default(PANEL_FN_VAR), widget_impl(ContextMenu, DefaultStyle))]
 pub fn panel_fn(child: impl IntoUiNode, panel: impl IntoVar<WidgetFn<zng_wgt_panel::PanelArgs>>) -> UiNode {
     with_context_var(child, PANEL_FN_VAR, panel)
 }

--- a/crates/zng-wgt-menu/src/lib.rs
+++ b/crates/zng-wgt-menu/src/lib.rs
@@ -63,13 +63,13 @@ context_var! {
 /// This property sets [`PANEL_FN_VAR`].
 ///
 /// [`Menu!`]: struct@Menu
-#[property(CONTEXT, default(PANEL_FN_VAR), widget_impl(Menu))]
+#[property(CONTEXT, default(PANEL_FN_VAR), widget_impl(Menu, DefaultStyle))]
 pub fn panel_fn(child: impl IntoUiNode, panel: impl IntoVar<WidgetFn<zng_wgt_panel::PanelArgs>>) -> UiNode {
     with_context_var(child, PANEL_FN_VAR, panel)
 }
 
 /// Gets if any descendant sub-menu is open.
-#[property(EVENT + 1, widget_impl(Menu))]
+#[property(EVENT + 1, widget_impl(Menu, DefaultStyle))]
 pub fn has_open(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
     // EVENT+1 to clear the `sub_menu_node` in case this is set in a sub-menu that
     // sub-menu will see the parent OPEN_SUBMENU_VAR for setting its own state

--- a/crates/zng-wgt-menu/src/popup.rs
+++ b/crates/zng-wgt-menu/src/popup.rs
@@ -75,7 +75,7 @@ context_var! {
 /// Widget function that generates the sub-menu popup layout.
 ///
 /// This property sets [`PANEL_FN_VAR`].
-#[property(CONTEXT, default(PANEL_FN_VAR), widget_impl(SubMenuPopup))]
+#[property(CONTEXT, default(PANEL_FN_VAR), widget_impl(SubMenuPopup, DefaultStyle))]
 pub fn panel_fn(child: impl IntoUiNode, panel: impl IntoVar<WidgetFn<zng_wgt_panel::PanelArgs>>) -> UiNode {
     with_context_var(child, PANEL_FN_VAR, panel)
 }

--- a/crates/zng-wgt-menu/src/sub.rs
+++ b/crates/zng-wgt-menu/src/sub.rs
@@ -326,7 +326,7 @@ pub fn header(wgt: &mut WidgetBuilding, child: impl IntoUiNode) {
 /// Width of the icon/checkmark column.
 ///
 /// This property sets [`START_COLUMN_WIDTH_VAR`].
-#[property(CONTEXT, default(START_COLUMN_WIDTH_VAR), widget_impl(SubMenu))]
+#[property(CONTEXT, default(START_COLUMN_WIDTH_VAR), widget_impl(SubMenu, DefaultStyle))]
 pub fn start_column_width(child: impl IntoUiNode, width: impl IntoVar<Length>) -> UiNode {
     with_context_var(child, START_COLUMN_WIDTH_VAR, width)
 }
@@ -334,7 +334,7 @@ pub fn start_column_width(child: impl IntoUiNode, width: impl IntoVar<Length>) -
 /// Width of the sub-menu expand symbol column.
 ///
 /// This property sets [`END_COLUMN_WIDTH_VAR`].
-#[property(CONTEXT, default(END_COLUMN_WIDTH_VAR), widget_impl(SubMenu))]
+#[property(CONTEXT, default(END_COLUMN_WIDTH_VAR), widget_impl(SubMenu, DefaultStyle))]
 pub fn end_column_width(child: impl IntoUiNode, width: impl IntoVar<Length>) -> UiNode {
     with_context_var(child, END_COLUMN_WIDTH_VAR, width)
 }
@@ -445,7 +445,7 @@ context_var! {
 }
 
 /// If the sub-menu popup is open or opening.
-#[property(EVENT, widget_impl(SubMenu))]
+#[property(EVENT, widget_impl(SubMenu, DefaultStyle))]
 pub fn is_open(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
     bind_state(child, IS_OPEN_VAR, state)
 }
@@ -455,7 +455,7 @@ pub fn is_open(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
 /// Is `300.ms()` by default.
 ///
 /// This property sets the [`HOVER_OPEN_DELAY_VAR`].
-#[property(CONTEXT, default(HOVER_OPEN_DELAY_VAR), widget_impl(SubMenu))]
+#[property(CONTEXT, default(HOVER_OPEN_DELAY_VAR), widget_impl(SubMenu, DefaultStyle))]
 pub fn hover_open_delay(child: impl IntoUiNode, delay: impl IntoVar<Duration>) -> UiNode {
     with_context_var(child, HOVER_OPEN_DELAY_VAR, delay)
 }

--- a/crates/zng-wgt-progress/src/lib.rs
+++ b/crates/zng-wgt-progress/src/lib.rs
@@ -43,7 +43,7 @@ pub fn progress(child: impl IntoUiNode, progress: impl IntoVar<Progress>) -> UiN
 }
 
 /// Collapse visibility when [`Progress::is_complete`].
-#[property(CONTEXT, default(false), widget_impl(ProgressView))]
+#[property(CONTEXT, default(false), widget_impl(ProgressView, DefaultStyle))]
 pub fn collapse_complete(child: impl IntoUiNode, collapse: impl IntoVar<bool>) -> UiNode {
     let collapse = collapse.into_var();
     visibility(
@@ -130,7 +130,7 @@ pub fn on_complete(child: impl IntoUiNode, handler: Handler<Progress>) -> UiNode
 /// Getter property that is `true` when progress is indeterminate.
 ///
 /// This event works in any context that sets [`PROGRESS_VAR`].
-#[property(EVENT, widget_impl(ProgressView))]
+#[property(EVENT, widget_impl(ProgressView, DefaultStyle))]
 pub fn is_indeterminate(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
     bind_state(child, PROGRESS_VAR.map(|p| p.is_indeterminate()), state)
 }

--- a/crates/zng-wgt-slider/src/lib.rs
+++ b/crates/zng-wgt-slider/src/lib.rs
@@ -475,7 +475,7 @@ context_var! {
 /// Defines the orientation and direction of the slider track.
 ///
 /// This property sets the [`SLIDER_DIRECTION_VAR`].
-#[property(CONTEXT, default(SLIDER_DIRECTION_VAR), widget_impl(Slider))]
+#[property(CONTEXT, default(SLIDER_DIRECTION_VAR), widget_impl(Slider, DefaultStyle))]
 fn direction(child: impl IntoUiNode, direction: impl IntoVar<SliderDirection>) -> UiNode {
     with_context_var(child, SLIDER_DIRECTION_VAR, direction)
 }

--- a/crates/zng-wgt-text-input/src/text_input.rs
+++ b/crates/zng-wgt-text-input/src/text_input.rs
@@ -232,7 +232,7 @@ impl SearchStyle {
 ///
 /// The placeholder has the same text style as the parent widget, with 50% opacity.
 /// You can use the [`placeholder`](fn@placeholder) to use a custom widget placeholder.
-#[property(CHILD, default(""), widget_impl(TextInput))]
+#[property(CHILD, default(""), widget_impl(TextInput, DefaultStyle))]
 pub fn placeholder_txt(child: impl IntoUiNode, txt: impl IntoVar<Txt>) -> UiNode {
     placeholder(
         child,
@@ -247,7 +247,7 @@ pub fn placeholder_txt(child: impl IntoUiNode, txt: impl IntoVar<Txt>) -> UiNode
 /// Widget shown when the `txt` is empty.
 ///
 /// The `placeholder` can be any widget, the `Text!` widget is recommended.
-#[property(CHILD, widget_impl(TextInput))]
+#[property(CHILD, widget_impl(TextInput, DefaultStyle))]
 pub fn placeholder(child: impl IntoUiNode, placeholder: impl IntoUiNode) -> UiNode {
     let mut txt_is_empty = None;
     zng_wgt_container::child_under(

--- a/crates/zng-wgt-toggle/src/lib.rs
+++ b/crates/zng-wgt-toggle/src/lib.rs
@@ -226,7 +226,7 @@ pub fn tristate(child: impl IntoUiNode, enabled: impl IntoVar<bool>) -> UiNode {
 /// If the toggle is checked from any of the three primary properties.
 ///
 /// Note to read the tristate directly use [`IS_CHECKED_VAR`] directly.
-#[property(EVENT, widget_impl(Toggle))]
+#[property(EVENT, widget_impl(Toggle, DefaultStyle))]
 pub fn is_checked(child: impl IntoUiNode, state: impl IntoVar<bool>) -> UiNode {
     bind_state(child, IS_CHECKED_VAR.map(|s| *s == Some(true)), state)
 }
@@ -488,7 +488,7 @@ fn value_impl(child: impl IntoUiNode, value: AnyVar) -> UiNode {
 /// This is enabled by default.
 ///
 /// [`value`]: fn@value
-#[property(CONTEXT, default(SCROLL_ON_SELECT_VAR), widget_impl(Toggle))]
+#[property(CONTEXT, default(SCROLL_ON_SELECT_VAR), widget_impl(Toggle, DefaultStyle))]
 pub fn scroll_on_select(child: impl IntoUiNode, enabled: impl IntoVar<bool>) -> UiNode {
     with_context_var(child, SCROLL_ON_SELECT_VAR, enabled)
 }

--- a/crates/zng-wgt-window/src/lib.rs
+++ b/crates/zng-wgt-window/src/lib.rs
@@ -147,9 +147,6 @@ impl DefaultStyle {
             }
         }
     }
-
-    // !!: TODO implement all style oriented Window properties? Is this or need to reexport them all
-    // Maybe widget_impl can accept multiple widgets?
 }
 
 /// Padding required to avoid physical screen obstructions.
@@ -158,7 +155,7 @@ impl DefaultStyle {
 /// unset this property to implement your own *unsafe area* handling.
 ///
 /// [`WINDOW.vars().safe_padding()`]: zng_ext_window::WindowVars::safe_padding
-#[property(CHILD_LAYOUT, default(0), widget_impl(Window))]
+#[property(CHILD_LAYOUT, default(0), widget_impl(Window, DefaultStyle))]
 pub fn safe_padding(child: impl IntoUiNode, padding: impl IntoVar<SideOffsets>) -> UiNode {
     zng_wgt_container::padding(child, padding)
 }

--- a/crates/zng-wgt-window/src/lib.rs
+++ b/crates/zng-wgt-window/src/lib.rs
@@ -161,7 +161,7 @@ pub fn safe_padding(child: impl IntoUiNode, padding: impl IntoVar<SideOffsets>) 
 }
 
 /// Defines how the window is positioned when it first opens.
-#[property(LAYOUT, widget_impl(Window))]
+#[property(LAYOUT, widget_impl(Window, DefaultStyle))]
 pub fn start_position(wgt: &mut WidgetBuilding, position: impl IntoValue<StartPosition>) {
     let _ = position;
     wgt.expect_property_capture();
@@ -199,7 +199,7 @@ pub fn kiosk(wgt: &mut WidgetBuilding, kiosk: impl IntoValue<bool>) {
 ///
 /// [`clear_color`]: fn@clear_color
 /// [`background_color`]: fn@background_color
-#[property(CONTEXT, widget_impl(Window))]
+#[property(CONTEXT, widget_impl(Window, DefaultStyle))]
 pub fn allow_transparency(wgt: &mut WidgetBuilding, allow: impl IntoValue<bool>) {
     let _ = allow;
     wgt.expect_property_capture();

--- a/crates/zng-wgt-window/src/window_properties.rs
+++ b/crates/zng-wgt-window/src/window_properties.rs
@@ -15,7 +15,7 @@ use zng_wgt_layer::adorner_fn;
 #[cfg(feature = "image")]
 use zng_ext_window::FrameCaptureMode;
 
-use super::Window;
+use super::{DefaultStyle, Window};
 
 fn bind_window_var<T>(child: impl IntoUiNode, user_var: impl IntoVar<T>, select: impl Fn(&WindowVars) -> Var<T> + Send + 'static) -> UiNode
 where
@@ -45,7 +45,7 @@ macro_rules! set_properties {
             #[doc = "Binds the [`"$ident "`](fn@WindowVars::"$ident ") window var with the property value."]
             ///
             /// The binding is bidirectional and the window variable is assigned on init.
-            #[property(CONTEXT, widget_impl(Window))]
+            #[property(CONTEXT, widget_impl(Window, DefaultStyle))]
             pub fn $ident(child: impl IntoUiNode, $ident: impl IntoVar<$Type>) -> UiNode {
                 bind_window_var(child, $ident, |w|w.$ident().clone())
             }
@@ -101,7 +101,7 @@ macro_rules! map_properties {
         #[doc = "Binds the `"$member "` of the [`"$ident "`](fn@WindowVars::"$ident ") window var with the property value."]
         ///
         /// The binding is bidirectional and the window variable is assigned on init.
-        #[property(CONTEXT, widget_impl(Window))]
+        #[property(CONTEXT, widget_impl(Window, DefaultStyle))]
         pub fn $name(child: impl IntoUiNode, $name: impl IntoVar<$Type>) -> UiNode {
             bind_window_var(child, $name, |w|w.$ident().map_bidi_modify(|v| v.$member.clone(), |v, m|m.$member = v.clone()))
         }
@@ -125,7 +125,7 @@ map_properties! {
 /// It is visible if window content does not completely fill the content area, this
 /// can happen if you do not set a background or the background is semi-transparent, also
 /// can happen during very fast resizes.
-#[property(LAYOUT-1, default(colors::WHITE), widget_impl(Window))]
+#[property(LAYOUT-1, default(colors::WHITE), widget_impl(Window, DefaultStyle))]
 pub fn clear_color(child: impl IntoUiNode, color: impl IntoVar<Rgba>) -> UiNode {
     let clear_color = color.into_var();
     match_node(child, move |_, op| match op {
@@ -487,7 +487,7 @@ pub fn needs_fallback_chrome(child: impl IntoUiNode, needs: impl IntoVar<bool>) 
 ///
 /// [`chrome`]: fn@chrome
 /// [`WINDOWS.system_chrome`]: WINDOWS::system_chrome
-#[property(EVENT, default(var_state()), widget_impl(Window))]
+#[property(EVENT, default(var_state()), widget_impl(Window, DefaultStyle))]
 pub fn prefer_custom_chrome(child: impl IntoUiNode, prefer: impl IntoVar<bool>) -> UiNode {
     zng_wgt::node::bind_state(child, WINDOWS.system_chrome().map(|c| c.prefer_custom), prefer)
 }
@@ -500,7 +500,7 @@ pub fn prefer_custom_chrome(child: impl IntoUiNode, prefer: impl IntoVar<bool>) 
 /// Note that you can also set the `custom_chrome_padding_fn` to ensure that the content is not hidden behind the adorner.
 ///
 /// [`adorner_fn`]: fn@adorner_fn
-#[property(FILL, default(WidgetFn::nil()), widget_impl(Window))]
+#[property(FILL, default(WidgetFn::nil()), widget_impl(Window, DefaultStyle))]
 pub fn custom_chrome_adorner_fn(child: impl IntoUiNode, custom_chrome: impl IntoVar<WidgetFn<()>>) -> UiNode {
     adorner_fn(child, custom_chrome)
 }
@@ -508,7 +508,7 @@ pub fn custom_chrome_adorner_fn(child: impl IntoUiNode, custom_chrome: impl Into
 /// Extra padding for window content in windows that display a [`custom_chrome_adorner_fn`].
 ///
 /// [`custom_chrome_adorner_fn`]: fn@custom_chrome_adorner_fn
-#[property(CHILD_LAYOUT, default(0), widget_impl(Window))]
+#[property(CHILD_LAYOUT, default(0), widget_impl(Window, DefaultStyle))]
 pub fn custom_chrome_padding_fn(child: impl IntoUiNode, padding: impl IntoVar<SideOffsets>) -> UiNode {
     zng_wgt_container::padding(child, padding)
 }

--- a/crates/zng/src/widget.rs
+++ b/crates/zng/src/widget.rs
@@ -684,8 +684,8 @@ pub use zng_app::widget::easing;
 ///
 /// #### Impl For
 ///
-/// The last argument is an optional `impl(<widget-type>)`, it strongly associates
-/// the property with a widget, users can set this property on the widget without needing to import the property.
+/// The last argument is an optional `impl(<widget-type>,...)`, it strongly associates the property with one or more widgets. 
+/// When a property is implemented on a widget users can set it without needing to import the property.
 ///
 /// Note that this makes the property have priority over all others of the same name, only a derived widget can override
 /// with another strongly associated property.

--- a/crates/zng/src/widget.rs
+++ b/crates/zng/src/widget.rs
@@ -684,7 +684,7 @@ pub use zng_app::widget::easing;
 ///
 /// #### Impl For
 ///
-/// The last argument is an optional `impl(<widget-type>,...)`, it strongly associates the property with one or more widgets. 
+/// The last argument is an optional `impl(<widget-type>,...)`, it strongly associates the property with one or more widgets.
 /// When a property is implemented on a widget users can set it without needing to import the property.
 ///
 /// Note that this makes the property have priority over all others of the same name, only a derived widget can override


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->