### PR TITLE
Fix warnings for release

### DIFF
--- a/crates/zng-view/src/gl.rs
+++ b/crates/zng-view/src/gl.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(any(feature = "hardware",  feature = "software"), allow(unused))]
+#![cfg_attr(any(feature = "hardware", feature = "software"), allow(unused))]
 
 use std::{cell::Cell, error::Error, fmt, mem, num::NonZeroU32, rc::Rc, thread};
 

--- a/crates/zng-view/src/gl.rs
+++ b/crates/zng-view/src/gl.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(any(feature = "hardware",  feature = "software"), allow(unused))]
+
 use std::{cell::Cell, error::Error, fmt, mem, num::NonZeroU32, rc::Rc, thread};
 
 use gleam::gl;


### PR DESCRIPTION
Some combinations of features causing unused warnings.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->