### PR TITLE
Disable memory profiler in tests and doctests

### DIFF
--- a/crates/zng-app/src/memory_profiler.rs
+++ b/crates/zng-app/src/memory_profiler.rs
@@ -1,6 +1,6 @@
 #![cfg(all(
     feature = "memory_profiler",
-    not(any(target_arch = "wasm32", target_os = "android", target_os = "ios"))
+    not(any(target_arch = "wasm32", target_os = "android", target_os = "ios", test, doc))
 ))]
 
 //! Memory profiler.


### PR DESCRIPTION
Its deadlocking in some test runs.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->