### PR TITLE
Image widget now ignores `img_scale_factor` when `img_scale_density` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Image widget now ignores `img_scale_factor` when `img_scale_density` is enabled.
 * Implement `FromStr` for `PxDensity`.
 
 # 0.19.0

--- a/crates/zng-wgt-image/src/image_properties.rs
+++ b/crates/zng-wgt-image/src/image_properties.rs
@@ -179,7 +179,10 @@ pub fn img_scale(child: impl IntoUiNode, scale: impl IntoVar<Factor2d>) -> UiNod
 ///
 /// This is enabled by default.
 ///
+/// See also [`img_scale_density`], for physical scaling in calibrated monitors.
+///
 /// [`img_crop`]: fn@img_crop
+/// [`img_scale_density`]: fn@img_scale_density
 #[property(CONTEXT, default(IMAGE_SCALE_FACTOR_VAR), widget_impl(Image))]
 pub fn img_scale_factor(child: impl IntoUiNode, enabled: impl IntoVar<bool>) -> UiNode {
     with_context_var(child, IMAGE_SCALE_FACTOR_VAR, enabled)
@@ -193,11 +196,14 @@ pub fn img_scale_factor(child: impl IntoUiNode, enabled: impl IntoVar<bool>) -> 
 /// By default this is `false`, if `true` the image is scaled in a attempt to recreate the original physical dimensions, this
 /// only works if the image and monitor pixel density are set correctly. The monitor pixel density can be set using the [`MONITORS`] service.
 ///
+/// This value supersedes [`img_scale_factor`], this this enabled the scale factor is ignored.
+///
 /// [`img_crop`]: fn@img_crop
 /// [`MONITORS`]: zng_ext_window::MONITORS
+/// [`img_scale_factor`]: fn@img_scale_factor
 #[property(CONTEXT, default(IMAGE_SCALE_DENSITY_VAR), widget_impl(Image))]
 pub fn img_scale_density(child: impl IntoUiNode, enabled: impl IntoVar<bool>) -> UiNode {
-    with_context_var(child, IMAGE_SCALE_DENSITY_VAR, enabled)
+    with_context_var(child, IMAGE_SCALE_DENSITY_VAR, enabled) // TODO(breaking) merge this property with `img_scale_factor`?
 }
 
 /// Sets the [`Align`] of all inner images within each image widget area.

--- a/crates/zng-wgt-image/src/node.rs
+++ b/crates/zng-wgt-image/src/node.rs
@@ -234,9 +234,9 @@ pub fn image_presenter() -> UiNode {
 
             let mut scale = IMAGE_SCALE_VAR.get();
             if IMAGE_SCALE_DENSITY_VAR.get() {
-                let sppi = metrics.screen_density();
-                let ippi = CONTEXT_IMAGE_VAR.with(Img::density).unwrap_or(PxDensity2d::splat(sppi));
-                scale *= Factor2d::new(sppi.ppcm() / ippi.width.ppcm(), sppi.ppcm() / ippi.height.ppcm());
+                let screen = metrics.screen_density();
+                let image = CONTEXT_IMAGE_VAR.with(Img::density).unwrap_or(PxDensity2d::splat(screen));
+                scale *= Factor2d::new(screen.ppcm() / image.width.ppcm(), screen.ppcm() / image.height.ppcm());
             }
             if IMAGE_SCALE_FACTOR_VAR.get() {
                 scale *= metrics.scale_factor();
@@ -263,9 +263,9 @@ pub fn image_presenter() -> UiNode {
 
             let mut scale = IMAGE_SCALE_VAR.get();
             if IMAGE_SCALE_DENSITY_VAR.get() {
-                let sppi = metrics.screen_density();
-                let ippi = CONTEXT_IMAGE_VAR.with(Img::density).unwrap_or(PxDensity2d::splat(sppi));
-                scale *= Factor2d::new(sppi.ppcm() / ippi.width.ppcm(), sppi.ppcm() / ippi.height.ppcm());
+                let screen = metrics.screen_density();
+                let image = CONTEXT_IMAGE_VAR.with(Img::density).unwrap_or(PxDensity2d::splat(screen));
+                scale *= Factor2d::new(screen.ppcm() / image.width.ppcm(), screen.ppcm() / image.height.ppcm());
             }
             if IMAGE_SCALE_FACTOR_VAR.get() {
                 scale *= metrics.scale_factor();

--- a/crates/zng-wgt-image/src/node.rs
+++ b/crates/zng-wgt-image/src/node.rs
@@ -237,8 +237,7 @@ pub fn image_presenter() -> UiNode {
                 let screen = metrics.screen_density();
                 let image = CONTEXT_IMAGE_VAR.with(Img::density).unwrap_or(PxDensity2d::splat(screen));
                 scale *= Factor2d::new(screen.ppcm() / image.width.ppcm(), screen.ppcm() / image.height.ppcm());
-            }
-            if IMAGE_SCALE_FACTOR_VAR.get() {
+            } else if IMAGE_SCALE_FACTOR_VAR.get() {
                 scale *= metrics.scale_factor();
             }
 
@@ -266,8 +265,7 @@ pub fn image_presenter() -> UiNode {
                 let screen = metrics.screen_density();
                 let image = CONTEXT_IMAGE_VAR.with(Img::density).unwrap_or(PxDensity2d::splat(screen));
                 scale *= Factor2d::new(screen.ppcm() / image.width.ppcm(), screen.ppcm() / image.height.ppcm());
-            }
-            if IMAGE_SCALE_FACTOR_VAR.get() {
+            } else if IMAGE_SCALE_FACTOR_VAR.get() {
                 scale *= metrics.scale_factor();
             }
 


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->