### PR TITLE
Implement workaround deadlocks caused by the `notify` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Implement workaround deadlocks caused by the `notify` crate.
 * Improve advanced animation API. 
     - Add `EasingTime::seg` helper for segmenting an animation overall time for sub-animations.
     - **Deprecated** `Animation::restart_count` renamed to `count`.

--- a/crates/zng-ext-fs-watcher/src/service.rs
+++ b/crates/zng-ext-fs-watcher/src/service.rs
@@ -383,5 +383,11 @@ impl WatcherService {
 }
 fn notify_watcher_handler() -> impl notify::EventHandler {
     let mut ctx = LocalContext::capture();
-    move |r| ctx.with_context(|| WATCHER_SV.write().on_watcher(r))
+    move |r| {
+        ctx.with_context(|| {
+            // this is an attempt to workaround https://github.com/notify-rs/notify/issues/463
+            // we have observed deadlocks inside notify code with a debugger
+            zng_task::spawn(async move { WATCHER_SV.write().on_watcher(r) });
+        })
+    }
 }

--- a/tests/macro-tests/cases/property/prefix_get_default.stderr
+++ b/tests/macro-tests/cases/property/prefix_get_default.stderr
@@ -17,21 +17,21 @@ help: consider annotating `NotDefault` with `#[derive(PartialEq)]`
    |
 
 error[E0277]: can't compare `NotDefault` with `NotDefault`
- --> cases/property/prefix_get_default.rs:9:1
-  |
-9 | #[property(CONTEXT)]
-  | ^^^^^^^^^^^^^^^^^^^^ no implementation for `NotDefault == NotDefault`
-  |
-  = help: the trait `PartialEq` is not implemented for `NotDefault`
-  = note: required for `NotDefault` to implement `VarValue`
+  --> cases/property/prefix_get_default.rs:9:1
+   |
+ 9 | #[property(CONTEXT)]
+   | ^^^^^^^^^^^^^^^^^^^^ no implementation for `NotDefault == NotDefault`
+   |
+   = help: the trait `PartialEq` is not implemented for `NotDefault`
+   = note: required for `NotDefault` to implement `VarValue`
 note: required by a bound in `zng::var::Var`
- --> $WORKSPACE/crates/zng-var/src/var.rs
-  |
-  | pub struct Var<T: VarValue> {
-  |                   ^^^^^^^^ required by this bound in `Var`
-  = note: this error originates in the attribute macro `property` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/crates/zng-var/src/var.rs
+   |
+   | pub struct Var<T: VarValue> {
+   |                   ^^^^^^^^ required by this bound in `Var`
+   = note: this error originates in the attribute macro `property` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NotDefault` with `#[derive(PartialEq)]`
-  |
+   |
 16 + #[derive(PartialEq)]
 17 | pub struct NotDefault {}
    |
@@ -98,20 +98,20 @@ help: consider annotating `NotDefault` with `#[derive(PartialEq)]`
    |
 
 error[E0277]: can't compare `NotDefault` with `NotDefault`
- --> cases/property/prefix_get_default.rs:9:1
-  |
-9 | #[property(CONTEXT)]
-  | ^^^^^^^^^^^^^^^^^^^^ no implementation for `NotDefault == NotDefault`
-  |
-  = help: the trait `PartialEq` is not implemented for `NotDefault`
-  = note: required for `NotDefault` to implement `VarValue`
+  --> cases/property/prefix_get_default.rs:9:1
+   |
+ 9 | #[property(CONTEXT)]
+   | ^^^^^^^^^^^^^^^^^^^^ no implementation for `NotDefault == NotDefault`
+   |
+   = help: the trait `PartialEq` is not implemented for `NotDefault`
+   = note: required for `NotDefault` to implement `VarValue`
 note: required by a bound in `zng::var::Var`
- --> $WORKSPACE/crates/zng-var/src/var.rs
-  |
-  | pub struct Var<T: VarValue> {
-  |                   ^^^^^^^^ required by this bound in `Var`
+  --> $WORKSPACE/crates/zng-var/src/var.rs
+   |
+   | pub struct Var<T: VarValue> {
+   |                   ^^^^^^^^ required by this bound in `Var`
 help: consider annotating `NotDefault` with `#[derive(PartialEq)]`
-  |
+   |
 16 + #[derive(PartialEq)]
 17 | pub struct NotDefault {}
    |
@@ -146,23 +146,23 @@ error[E0308]: mismatched types
   = note: this error originates in the attribute macro `property` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotDefault: VarValue` is not satisfied
- --> cases/property/prefix_get_default.rs:9:1
-  |
-9 | #[property(CONTEXT)]
-  | ^^^^^^^^^^^^^^^^^^^^ the trait `PartialEq` is not implemented for `NotDefault`
-  |
-  = note: required for `NotDefault` to implement `VarValue`
+  --> cases/property/prefix_get_default.rs:9:1
+   |
+ 9 | #[property(CONTEXT)]
+   | ^^^^^^^^^^^^^^^^^^^^ the trait `PartialEq` is not implemented for `NotDefault`
+   |
+   = note: required for `NotDefault` to implement `VarValue`
 note: required by a bound in `var_to_args`
- --> $WORKSPACE/crates/zng-app/src/widget/builder.rs
-  |
-  | pub fn var_to_args<T: VarValue>(var: impl IntoVar<T>) -> Var<T> {
-  |                       ^^^^^^^^ required by this bound in `var_to_args`
-  = note: this error originates in the attribute macro `property` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/crates/zng-app/src/widget/builder.rs
+   |
+   | pub fn var_to_args<T: VarValue>(var: impl IntoVar<T>) -> Var<T> {
+   |                       ^^^^^^^^ required by this bound in `var_to_args`
+   = note: this error originates in the attribute macro `property` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NotDefault` with `#[derive(PartialEq)]`
-  |
- 16 + #[derive(PartialEq)]
- 17 | pub struct NotDefault {}
-    |
+   |
+16 + #[derive(PartialEq)]
+17 | pub struct NotDefault {}
+   |
 
 error[E0277]: the trait bound `NotDefault: VarValue` is not satisfied
   --> cases/property/prefix_get_default.rs:10:70
@@ -178,6 +178,6 @@ note: required by a bound in `WhenInputVar::new`
    |                   ^^^^^^^^ required by this bound in `WhenInputVar::new`
 help: consider annotating `NotDefault` with `#[derive(PartialEq)]`
    |
-  16 + #[derive(PartialEq)]
-  17 | pub struct NotDefault {}
-     |
+16 + #[derive(PartialEq)]
+17 | pub struct NotDefault {}
+   |


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->