### PR TITLE
Refactor `IpcBytes` to accept allocations above `u32::MAX`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Refactor view-process API `IpcBytes` to accept transfers of over 2GB.
+    - **Deprecated** deref to `[u8]`.
+    - Added `IpcBytes::{parts_len, part, parts}` to access the underlying parts.
+* Refactor `ImageCacheProxy` API to make no distinction between image request and data interceptors.
 * Implement workaround deadlocks caused by the `notify` crate.
 * Improve advanced animation API. 
     - Add `EasingTime::seg` helper for segmenting an animation overall time for sub-animations.

--- a/crates/zng-app/src/view_process.rs
+++ b/crates/zng-app/src/view_process.rs
@@ -1357,7 +1357,7 @@ impl ViewImage {
     ///
     /// [`is_mask`]: Self::is_mask
     pub fn partial_pixels(&self) -> Option<Vec<u8>> {
-        self.0.read().partial_pixels.as_ref().map(|r| r[..].to_vec())
+        self.0.read().partial_pixels.as_ref().map(|r| r.clone().to_vec())
     }
 
     /// Reference the decoded pixels of image.

--- a/crates/zng-ext-image/src/lib.rs
+++ b/crates/zng-ext-image/src/lib.rs
@@ -240,9 +240,7 @@ impl AppExtension for ImageManager {
                         Ok(data) => {
                             if let Some((key, mode)) = &t.is_data_proxy_source {
                                 for proxy in &mut proxies {
-                                    if proxy.is_data_proxy()
-                                        && let Some(replaced) = proxy.data(key, &data, &d.format, *mode, t.downscale, t.mask, true)
-                                    {
+                                    if let Some(replaced) = proxy.data_loaded(key, &data, &d.format, *mode, t.downscale, t.mask) {
                                         replaced.set_bind(&t.image).perm();
                                         t.image.hold(replaced).perm();
                                         continue 'loading_tasks;
@@ -536,10 +534,6 @@ impl ImagesService {
 
         let key = source.hash128(downscale, mask).unwrap();
         for proxy in &mut proxies {
-            if proxy.is_data_proxy() && !matches!(source, ImageSource::Data(_, _, _) | ImageSource::Static(_, _, _)) {
-                continue;
-            }
-
             let r = proxy.get(&key, &source, mode, downscale, mask);
             match r {
                 ProxyGetResult::None => continue,

--- a/crates/zng-view-api/src/app_process.rs
+++ b/crates/zng-view-api/src/app_process.rs
@@ -495,7 +495,7 @@ impl Controller {
             }
         }
 
-        let code_and_output = match process.wait() {
+        let exit_status = match process.wait() {
             Ok(c) => Some(c),
             Err(e) => {
                 tracing::error!(target: "vp_respawn", "view-process could not be killed, will abandon running, {e:?}");
@@ -504,7 +504,7 @@ impl Controller {
         };
 
         // try print stdout/err and exit code.
-        if let Some(c) = code_and_output {
+        if let Some(c) = exit_status {
             tracing::info!(target: "vp_respawn", "view-process killed");
 
             let code = c.code();


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->