### PR TITLE
Fix curl http version

### DIFF
--- a/crates/zng-task/src/http/curl.rs
+++ b/crates/zng-task/src/http/curl.rs
@@ -37,6 +37,8 @@ async fn run(request: Request) -> Result<Response, Error> {
         .stderr(std::process::Stdio::piped());
     curl.arg("--include"); // print header
 
+    curl.arg("--http1.1");
+
     curl.arg("-X").arg(request.method.as_str());
 
     #[cfg(feature = "http-compression")]


### PR DESCRIPTION
Parser only supports HTTP/1.1

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->