### PR TITLE
Fix missing image formats in the view-process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix missing image formats in the view-process encoder and decoder lists.
 
 # 0.20.1
 

--- a/crates/zng-app/src/view_process.rs
+++ b/crates/zng-app/src/view_process.rs
@@ -245,6 +245,7 @@ impl VIEW_PROCESS {
     ///
     /// Each text is the lower-case file extension, without the dot.
     pub fn image_encoders(&self) -> Result<Vec<Txt>> {
+        // TODO(breaking) change to a struct ImageFormat { mime: Txt, extensions: Box<[Txt]> }
         self.write().process.image_encoders()
     }
 

--- a/crates/zng-view/src/image_cache.rs
+++ b/crates/zng-view/src/image_cache.rs
@@ -4,6 +4,7 @@
 use image::ImageDecoder as _;
 use std::{fmt, sync::Arc};
 use zng_task::parking_lot::Mutex;
+use zng_view_api::image::ImageFormat;
 
 use webrender::api::ImageDescriptor;
 use zng_txt::ToTxt as _;
@@ -32,69 +33,38 @@ pub(crate) mod lcms2 {
     pub struct Profile {}
 }
 
-pub(crate) const ENCODERS: &[&str] = &[
-    #[cfg(feature = "image_png")]
-    "png",
-    #[cfg(feature = "image_jpeg")]
-    "jpg",
-    #[cfg(feature = "image_jpeg")]
-    "jpeg",
-    #[cfg(feature = "image_webp")]
-    "webp",
+pub(crate) const FORMATS: &[ImageFormat] = &[
     #[cfg(any(feature = "image_avif", zng_view_image_has_avif))]
-    "avif",
-    #[cfg(feature = "image_gif")]
-    "gif",
-    #[cfg(feature = "image_ico")]
-    "ico",
+    ImageFormat::from_static("AVIF", "avif", "avif", false),
     #[cfg(feature = "image_bmp")]
-    "bmp",
-    #[cfg(feature = "image_jpeg")]
-    "jfif",
-    #[cfg(feature = "image_exr")]
-    "exr",
-    #[cfg(feature = "image_hdr")]
-    "hdr",
-    #[cfg(feature = "image_pnm")]
-    "pnm",
-    #[cfg(feature = "image_qoi")]
-    "qoi",
-    #[cfg(feature = "image_ff")]
-    "ff",
-    #[cfg(feature = "image_ff")]
-    "farbfeld",
-];
-pub(crate) const DECODERS: &[&str] = &[
-    #[cfg(feature = "image_png")]
-    "png",
-    #[cfg(feature = "image_jpeg")]
-    "jpg",
-    #[cfg(feature = "image_jpeg")]
-    "jpeg",
-    #[cfg(feature = "image_webp")]
-    "webp",
-    #[cfg(any(feature = "image_avif", zng_view_image_has_avif))]
-    "avif",
-    #[cfg(feature = "image_gif")]
-    "gif",
-    #[cfg(feature = "image_ico")]
-    "ico",
-    #[cfg(feature = "image_bmp")]
-    "bmp",
-    #[cfg(feature = "image_jpeg")]
-    "jfif",
-    #[cfg(feature = "image_exr")]
-    "exr",
-    #[cfg(feature = "image_pnm")]
-    "pnm",
-    #[cfg(feature = "image_qoi")]
-    "qoi",
-    #[cfg(feature = "image_ff")]
-    "ff",
-    #[cfg(feature = "image_ff")]
-    "farbfeld",
+    ImageFormat::from_static("BMP", "bmp", "bmp,dib", true),
     #[cfg(feature = "image_dds")]
-    "dds",
+    ImageFormat::from_static("DirectDraw Surface", "x-direct-draw-surface", "dds", false),
+    #[cfg(feature = "image_exr")]
+    ImageFormat::from_static("OpenEXR", "x-exr", "exr", false),
+    #[cfg(feature = "image_ff")]
+    ImageFormat::from_static("Farbfeld", "farbfeld", "ff,farbfeld", false),
+    #[cfg(feature = "image_gif")]
+    ImageFormat::from_static("GIF", "gif", "gif", false),
+    #[cfg(feature = "image_hdr")]
+    ImageFormat::from_static("Radiance HDR", "vnd.radiance", "hdr", false),
+    #[cfg(feature = "image_ico")]
+    ImageFormat::from_static("ICO", "x-icon", "ico", true),
+    #[cfg(feature = "image_jpeg")]
+    ImageFormat::from_static("JPEG", "jpeg", "jpg,jpeg", true),
+    #[cfg(feature = "image_png")]
+    ImageFormat::from_static("PNG", "png", "png", true),
+    #[cfg(feature = "image_pnm")]
+    ImageFormat::from_static("PNM", "x-portable-bitmap", "pbm,pgm,ppm,pam", false),
+    // https://github.com/phoboslab/qoi/issues/167
+    #[cfg(feature = "image_qoi")]
+    ImageFormat::from_static("QOI", "x-qoi", "qoi", true),
+    #[cfg(feature = "image_tga")]
+    ImageFormat::from_static("TGA", "x-tga", "tga,icb,vda,vst", false),
+    #[cfg(feature = "image_tiff")]
+    ImageFormat::from_static("TIFF", "tiff", "tif,tiff", true),
+    #[cfg(feature = "image_tiff")]
+    ImageFormat::from_static("WebP", "webp", "webp", true),
 ];
 
 pub(crate) type ResizerCache = Mutex<fast_image_resize::Resizer>;

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -2077,11 +2077,18 @@ impl Api for App {
     }
 
     fn image_decoders(&mut self) -> Vec<Txt> {
-        image_cache::DECODERS.iter().map(|&s| Txt::from_static(s)).collect()
+        image_cache::FORMATS
+            .iter()
+            .flat_map(|f| f.file_extensions_iter().map(Txt::from_str))
+            .collect()
     }
 
     fn image_encoders(&mut self) -> Vec<Txt> {
-        image_cache::ENCODERS.iter().map(|&s| Txt::from_static(s)).collect()
+        image_cache::FORMATS
+            .iter()
+            .filter(|f| f.can_encode)
+            .flat_map(|f| f.file_extensions_iter().map(Txt::from_str))
+            .collect()
     }
 
     fn add_image(&mut self, request: ImageRequest<IpcBytes>) -> ImageId {


### PR DESCRIPTION
Some formats, like tiff, where supported but unlisted.

This commit also adds a new `ImageFormat` type that will be used in a future breaking release for better image format metadata support.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->