### PR TITLE
Fix lints Rust 1.92, allow `unused_assignments` globally

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,8 @@ DO_CMD = "cargo do"
 
 [alias]
 do = ["run", "--manifest-path", "tools/cargo-do/Cargo.toml", "--release", "--quiet", "--"]
+
+[build]
+# false positives in 1.92
+# see https://github.com/rust-lang/rust/issues/149889
+rustflags = ["-A", "unused_assignments"]

--- a/.github/workflows/check-features.yml
+++ b/.github/workflows/check-features.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings'
-  RUSTDOCFLAGS: '--deny=warnings'
+  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings -A unused_assignments'
+  RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ concurrency:
 
 env:
   RUST_BACKTRACE: 1
-  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings'
-  RUSTDOCFLAGS: '--deny=warnings'
+  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings -A unused_assignments'
+  RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
   NEXTEST_RETRIES: 3

--- a/.github/workflows/do.yml
+++ b/.github/workflows/do.yml
@@ -15,8 +15,8 @@ run-name: on ${{ github.event.inputs.runs-on }} do ${{ github.event.inputs.cargo
 
 env:
   RUST_BACKTRACE: 1
-  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings'
-  RUSTDOCFLAGS: '--deny=warnings'
+  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings -A unused_assignments'
+  RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
 

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings'
-  RUSTDOCFLAGS: '--deny=warnings'
+  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings -A unused_assignments'
+  RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ on:
     
 env:
   RUST_BACKTRACE: 1
-  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings'
-  RUSTDOCFLAGS: '--deny=warnings'
+  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings -A unused_assignments'
+  RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
   NEXTEST_RETRIES: 3

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings'
-  RUSTDOCFLAGS: '--deny=warnings'
+  RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings -A unused_assignments'
+  RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
 

--- a/crates/zng-app/src/handler.rs
+++ b/crates/zng-app/src/handler.rs
@@ -762,7 +762,7 @@ const DOC_TEST_BLOCK_ON_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[cfg(test)]
 mod tests {
-    use crate::handler::{Handler, async_hn, async_hn_once, hn, hn_once};
+    use crate::handler::Handler;
 
     #[test]
     fn hn_return() {

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -312,7 +312,6 @@ pub extern "C" fn extern_run_same_process(patch: &StaticPatch, run_app: extern "
         patch.install();
     }
 
-    #[expect(clippy::redundant_closure)] // false positive
     run_same_process(move || run_app())
 }
 #[cfg(ipc)]


### PR DESCRIPTION
Regression in Rust 1.92 causes this lint to show `unused_assignments` for all captures variables with underscore prefix, this is a lot of false positives because of the `match_node` pattern. For now I'm disabling this lint for the workspace in `.cargo/config.toml` and the CI scripts.

Rust issue: https://github.com/rust-lang/rust/issues/149889