### PR TITLE
Better `SettingsEditor!` screen when no item matches search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Better `SettingsEditor!` screen when no item matches search.
 * Change `presenter` and `presenter_opt` nodes to become the inner node if it is an widget.
 * Fix `force_size` layout causing an error log.
 * Fix `Scroll!` child alignment fill. Remove non standard layout, now only applies in dimensions without scrolling.

--- a/crates/zng-wgt-settings/l10n/en-US/_.ftl
+++ b/crates/zng-wgt-settings/l10n/en-US/_.ftl
@@ -1,4 +1,5 @@
 search =
+    .no_results = No settings found
     .placeholder = search settings ({$shortcut})
 
 window =

--- a/crates/zng-wgt-settings/l10n/pt-BR/_.ftl
+++ b/crates/zng-wgt-settings/l10n/pt-BR/_.ftl
@@ -1,4 +1,5 @@
 search =
+    .no_results = Nenhuma configuração encontrada
     .placeholder = procurar configurações ({$shortcut})
 
 window =

--- a/crates/zng-wgt-settings/l10n/template/_.ftl
+++ b/crates/zng-wgt-settings/l10n/template/_.ftl
@@ -2,6 +2,7 @@
 reset = Reset to default
 
 search =
+    .no_results = No settings found
     .placeholder = search settings ({$shortcut})
 
 window =

--- a/crates/zng-wgt-settings/src/lib.rs
+++ b/crates/zng-wgt-settings/src/lib.rs
@@ -188,9 +188,13 @@ fn editor_state() -> Var<Option<SettingsEditorState>> {
 }
 
 fn settings_view_fn() -> UiNode {
-    let search = SETTINGS_SEARCH_FN_VAR.get()(SettingsSearchArgs {});
-
     let editor_state = SETTINGS.editor_state().current_context();
+
+    let has_results = editor_state.map(|r| !r.as_ref().unwrap().categories.is_empty());
+
+    let search = SETTINGS_SEARCH_FN_VAR.get()(SettingsSearchArgs {
+        has_results: has_results.clone(),
+    });
 
     let categories = editor_state
         .map(|r| r.as_ref().unwrap().categories.clone())
@@ -235,6 +239,7 @@ fn settings_view_fn() -> UiNode {
         search,
         categories,
         settings,
+        has_results,
     })
 }
 

--- a/crates/zng-wgt-settings/src/view_fn.rs
+++ b/crates/zng-wgt-settings/src/view_fn.rs
@@ -275,6 +275,13 @@ pub fn default_panel_fn(args: PanelArgs) -> UiNode {
             child_start = args.categories;
             child = args.settings;
         };
+        when !*#{args.has_results} {
+            child = Text! {
+                txt = l10n!("search.no_results", "No settings found");
+                txt_align = Align::TOP;
+                zng_wgt::margin = 10;
+            }
+        }
     }
 }
 
@@ -367,9 +374,18 @@ impl SettingsArgs {
 /// Arguments for a search box widget.
 ///
 /// The search variable is in [`SETTINGS.editor_search`](SettingsCtxExt::editor_search).
-#[derive(Default)]
 #[non_exhaustive]
-pub struct SettingsSearchArgs {}
+pub struct SettingsSearchArgs {
+    /// If any settings matched the current search.
+    pub has_results: Var<bool>,
+}
+impl Default for SettingsSearchArgs {
+    fn default() -> Self {
+        Self {
+            has_results: true.into_var(),
+        }
+    }
+}
 
 /// Arguments for the entire settings editor layout.
 #[non_exhaustive]
@@ -380,6 +396,9 @@ pub struct PanelArgs {
     pub categories: UiNode,
     /// Settings widget.
     pub settings: UiNode,
+
+    /// If any settings matched the current search.
+    pub has_results: Var<bool>,
 }
 impl PanelArgs {
     /// New args.
@@ -388,6 +407,7 @@ impl PanelArgs {
             search,
             categories,
             settings,
+            has_results: true.into_var(),
         }
     }
 }

--- a/crates/zng-wgt-settings/src/view_fn.rs
+++ b/crates/zng-wgt-settings/src/view_fn.rs
@@ -280,7 +280,7 @@ pub fn default_panel_fn(args: PanelArgs) -> UiNode {
                 txt = l10n!("search.no_results", "No settings found");
                 txt_align = Align::TOP;
                 zng_wgt::margin = 10;
-            }
+            };
         }
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->