### PR TITLE
Fix memory leak in `Var::flat_map_vec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix memory leak in `Var::flat_map_vec` when the returned item var is a retained clone.
+
 * **Breaking** `FileDialogFilters::push_filter` now accepts any `IntoIterator<Item=str>`.
 
 * Better runtime info about supported image formats.

--- a/crates/zng-var/src/var.rs
+++ b/crates/zng-var/src/var.rs
@@ -612,18 +612,16 @@ impl<T: VarValue> Var<Vec<T>> {
     /// [`flat_map`]: Self::flat_map
     pub fn flat_map_vec<O: VarValue>(&self, mut map: impl FnMut(usize, &T) -> Var<O> + Send + 'static) -> Var<Vec<O>> {
         self.flat_map(move |vec| {
-            let item_vars: Vec<Var<O>> = vec.iter().enumerate().map(|(i, it)| map(i, it)).collect();
-            let out_value: Vec<O> = item_vars.iter().map(|v| v.get()).collect();
+            let mut item_vars: Vec<(Var<O>, VarHandle)> = vec.iter().enumerate().map(|(i, it)| (map(i, it), VarHandle::dummy())).collect();
+            let out_value: Vec<O> = item_vars.iter().map(|v| v.0.get()).collect();
             let out_var = crate::var(out_value);
 
-            for (i, item_var) in item_vars.iter().enumerate() {
-                item_var
-                    .bind_modify(&out_var, move |item_value, out_value| {
-                        if &out_value.value()[i] != item_value {
-                            out_value.value_mut()[i] = item_value.clone();
-                        }
-                    })
-                    .perm(); // TODO(breaking) this is a leak if map returns a variable that lives longer than flat_map
+            for (i, (item_var, handle)) in item_vars.iter_mut().enumerate() {
+                *handle = item_var.bind_modify(&out_var, move |item_value, out_value| {
+                    if &out_value.value()[i] != item_value {
+                        out_value.value_mut()[i] = item_value.clone();
+                    }
+                });
             }
             out_var.hold(item_vars).perm();
 


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->