### PR TITLE
Normalize length operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* **Breaking** Length units `max`, `min` and `abs` now take by value.
+
 * **Breaking** `FileDialogFilters::push_filter` now accepts any `IntoIterator<Item=str>`.
 
 * Better runtime info about supported image formats.

--- a/crates/zng-layout/src/unit/length.rs
+++ b/crates/zng-layout/src/unit/length.rs
@@ -597,14 +597,12 @@ impl Length {
     }
 
     /// Returns a length that resolves to the maximum layout length between `self` and `other`.
-    pub fn max(&self, other: impl Into<Length>) -> Length {
-        // TODO(breaking) take `self`
-        let mut self_ = self.clone();
+    pub fn max(mut self, other: impl Into<Length>) -> Length {
         let mut other = other.into();
-        if self_.try_max(&mut other) {
-            self_
+        if self.try_max(&mut other) {
+            self
         } else {
-            LengthExpr::Max(self_, other).to_length_checked()
+            LengthExpr::Max(self, other).to_length_checked()
         }
     }
     pub(crate) fn try_max(&mut self, other: &mut Self) -> bool {
@@ -637,14 +635,12 @@ impl Length {
     }
 
     /// Returns a length that resolves to the minimum layout length between `self` and `other`.
-    pub fn min(&self, other: impl Into<Length>) -> Length {
-        // TODO(breaking) take `self`
-        let mut self_ = self.clone();
+    pub fn min(mut self, other: impl Into<Length>) -> Length {
         let mut other = other.into();
-        if self_.try_min(&mut other) {
-            self_
+        if self.try_min(&mut other) {
+            self
         } else {
-            LengthExpr::Min(self_, other).to_length_checked()
+            LengthExpr::Min(self, other).to_length_checked()
         }
     }
     pub(crate) fn try_min(&mut self, other: &mut Self) -> bool {
@@ -677,14 +673,12 @@ impl Length {
     }
 
     /// Returns a length that constraints the computed layout length between `min` and `max`.
-    pub fn clamp(&self, min: impl Into<Length>, max: impl Into<Length>) -> Length {
-        // TODO(breaking) take `self`
+    pub fn clamp(self, min: impl Into<Length>, max: impl Into<Length>) -> Length {
         self.max(min).min(max)
     }
 
     /// Returns a length that computes the absolute layout length of `self`.
-    pub fn abs(&self) -> Length {
-        // TODO(breaking) take `self`
+    pub fn abs(self) -> Length {
         use Length::*;
         match self {
             Default => LengthExpr::Abs(Length::Default).to_length_checked(),
@@ -701,7 +695,7 @@ impl Length {
             ViewportMax(m) => ViewportMax(m.abs()),
             DipF32(e) => DipF32(e.abs()),
             PxF32(e) => PxF32(e.abs()),
-            Expr(e) => LengthExpr::Abs(Length::Expr(e.clone())).to_length_checked(),
+            Expr(e) => LengthExpr::Abs(Length::Expr(e)).to_length_checked(),
         }
     }
 

--- a/crates/zng-layout/src/unit/vector.rs
+++ b/crates/zng-layout/src/unit/vector.rs
@@ -91,7 +91,7 @@ impl Vector {
     }
 
     /// Returns a vector that computes the absolute layout vector of `self`.
-    pub fn abs(&self) -> Vector {
+    pub fn abs(self) -> Vector {
         Vector {
             x: self.x.abs(),
             y: self.y.abs(),


### PR DESCRIPTION
Length units `max`, `min` and `abs` now take by value. These operations usually take `self` in other types.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->