### PR TITLE
Downgrade bincode dependency

### DIFF
--- a/crates/zng-task/Cargo.toml
+++ b/crates/zng-task/Cargo.toml
@@ -62,7 +62,7 @@ zng-unique-id = { path = "../zng-unique-id", version = "0.10.0", default-feature
 
 tracing = { version = "0.1", default-features = false }
 pretty-type-name = { version = "1.0", default-features = false }
-flume = { version = "0.11", default-features = false, features = ["async"] }
+flume = { version = "0.12", default-features = false, features = ["async"] }
 rayon = { version = "1.10", default-features = false }
 blocking = { version = "1.5", default-features = false }
 parking_lot = { version = "0.12", default-features = false }

--- a/crates/zng-tp-licenses/Cargo.toml
+++ b/crates/zng-tp-licenses/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
 deflate = { version = "1.0", default-features = false, optional = true }
 inflate = { version = "0.4", default-features = false, optional = true }
-bincode = { version = "2.0", default-features = false, optional = true, features = ["std", "serde"]}
+bincode = { version = "1", default-features = false, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 tempfile = { version = "3.10", default-features = false }

--- a/crates/zng-tp-licenses/src/lib.rs
+++ b/crates/zng-tp-licenses/src/lib.rs
@@ -266,7 +266,7 @@ pub fn parse_cargo_about(json: &str) -> Result<Vec<LicenseUsed>, serde_json::Err
 /// Panics in case of any error.
 #[cfg(feature = "build")]
 pub fn encode_licenses(licenses: &[LicenseUsed]) -> Vec<u8> {
-    deflate::deflate_bytes(&bincode::serde::encode_to_vec(licenses, bincode::config::standard()).expect("bincode error"))
+    deflate::deflate_bytes(&bincode::serialize(licenses).expect("bincode error"))
 }
 
 /// Encode licenses and write to the output file that is included by [`include_bundle!`].

--- a/crates/zng-tp-licenses/src/lib.rs
+++ b/crates/zng-tp-licenses/src/lib.rs
@@ -297,7 +297,5 @@ macro_rules! include_bundle {
 #[cfg(feature = "bundle")]
 pub fn decode_licenses(bin: &[u8]) -> Vec<LicenseUsed> {
     let bin = inflate::inflate_bytes(bin).expect("invalid bundle deflate binary");
-    bincode::serde::decode_from_slice(&bin, bincode::config::standard())
-        .expect("invalid bundle bincode binary")
-        .0
+    bincode::deserialize(&bin).expect("invalid bundle bincode binary")
 }

--- a/crates/zng-view-api/Cargo.toml
+++ b/crates/zng-view-api/Cargo.toml
@@ -43,7 +43,7 @@ rustc-hash = { version = "2.0", default-features = false, features = ["std"] }
 bitflags = { version = "2.5", default-features = false, features = ["serde", "bytemuck"] }
 bytemuck = { version = "1.15", default-features = false, features = ["derive"] }
 
-bincode = { version = "2.0", default-features = false, features = ["serde", "std"] }
+bincode = { version = "1", default-features = false }
 parking_lot = { version = "0.12", default-features = false }
 serde_variant = { version = "0.1", default-features = false }
 


### PR DESCRIPTION
There is some weirdness with this package and it will probably become a unmaintained security issue in the future, for now this goes back to version 1.3.3 that is the stable version used by `ipc-channel`, hopefully we can just follow what ipc-channel does in the future.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->