### PR TITLE
Optimized `Txt`, now it is 24 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Optimized `Txt`, now it is 24 bytes.
+    - **Breaking** `Txt::from_string` is no longer const.
+
 * Refactor `IMAGES` service extending.
     - **Breaking** Removed `ImageCacheProxy` API.
     - Added similar `ImagesExtension` API.


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->