### PR TITLE
Refactor `Img` to be a normal state snapshot now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+* Refactor `Img`, it is now a normal value.
+    - Fixes `ImageVar` sometimes not updating correctly in complex bindings.
+    - **Breaking** Replaced advanced `ViewImage` with `ViewImageHandle`.
+    - **Breaking** Multiple changes in the `Img` methods.
+    - All image loading now is managed by the `IMAGES` service in the app-process.
+
 * **Breaking** Add system tray icon and app menu to the view API.
     - Service not implemented yet, this will happen in a future non breaking release.
 
@@ -49,8 +55,6 @@
     - Added `WINDOWS.available_operations` with what window operations the view-process implements.
     - Added `DIALOG.available_native_dialogs` with what native dialogs the view-process implements.
     - Added `CLIPBOARD.available_types` with what data types can be read/write by the view-process implementation.
-
-* Fix `ImageVar` updates not propagating in some complex bindings.
 
 * Fix `cargo zng l10n --clean-template` removing custom template localization files.
 * Fix `cargo zng l10n` not including entries of local dependencies targeting the same localization file.

--- a/crates/zng-app/src/running.rs
+++ b/crates/zng-app/src/running.rs
@@ -357,43 +357,30 @@ impl<E: AppExtension> RunningApp<E> {
                 self.notify_event(RAW_WINDOW_CLOSE_EVENT.new_update(args), observer);
             }
             Event::ImageMetadataDecoded(meta) => {
-                if let Some(img) = VIEW_PROCESS.on_image_metadata(meta) {
-                    let args = RawImageArgs::now(img);
-                    self.notify_event(RAW_IMAGE_METADATA_LOADED_EVENT.new_update(args), observer);
-                }
-            }
-            Event::ImagePartiallyDecoded(img) => {
-                if let Some(img) = VIEW_PROCESS.on_image_partially_decoded(img) {
-                    let args = RawImageArgs::now(img);
-                    self.notify_event(RAW_IMAGE_PARTIALLY_LOADED_EVENT.new_update(args), observer);
+                if let Some(handle) = VIEW_PROCESS.on_image_metadata(&meta) {
+                    let args = RawImageMetadataDecodedArgs::now(handle, meta);
+                    self.notify_event(RAW_IMAGE_METADATA_DECODED_EVENT.new_update(args), observer);
+                } else {
+                    tracing::warn!("received unknown image metadata {:?} ({:?}), ignoring", meta.id, meta.size);
                 }
             }
             Event::ImageDecoded(img) => {
-                if let Some(img) = VIEW_PROCESS.on_image_decoded(img) {
-                    let args = RawImageArgs::now(img);
-                    self.notify_event(RAW_IMAGE_LOADED_EVENT.new_update(args), observer);
+                if let Some(handle) = VIEW_PROCESS.on_image_decoded(&img) {
+                    let args = RawImageDecodedArgs::now(handle, img);
+                    self.notify_event(RAW_IMAGE_DECODED_EVENT.new_update(args), observer);
+                 }else {
+                    tracing::warn!("received unknown image metadata {:?} ({:?}), ignoring", img.meta.id, img.meta.size);
                 }
             }
             Event::ImageDecodeError { image: id, error } => {
-                if let Some(img) = VIEW_PROCESS.on_image_error(id, error) {
-                    let args = RawImageArgs::now(img);
-                    self.notify_event(RAW_IMAGE_LOAD_ERROR_EVENT.new_update(args), observer);
+                if let Some(handle) = VIEW_PROCESS.on_image_error(id) {
+                    let args = RawImageDecodeErrorArgs::now(handle, error);
+                    self.notify_event(RAW_IMAGE_DECODE_ERROR_EVENT.new_update(args), observer);
                 }
             }
             Event::ImageEncoded { task, data } => VIEW_PROCESS.on_image_encoded(task, data),
             Event::ImageEncodeError { task, error } => {
                 VIEW_PROCESS.on_image_encode_error(task, error);
-            }
-            Event::FrameImageReady {
-                window: w_id,
-                frame: frame_id,
-                image: image_id,
-                selection,
-            } => {
-                if let Some(img) = VIEW_PROCESS.on_frame_image_ready(image_id) {
-                    let args = RawFrameImageReadyArgs::now(img, window_id(w_id), frame_id, selection);
-                    self.notify_event(RAW_FRAME_IMAGE_READY_EVENT.new_update(args), observer);
-                }
             }
 
             Event::AccessInit { window: w_id } => {
@@ -530,7 +517,7 @@ impl<E: AppExtension> RunningApp<E> {
         debug_assert!(ev.window != zng_view_api::window::WindowId::INVALID);
         let window_id = WindowId::from_raw(ev.window.get());
         // view.on_frame_rendered(window_id); // already called in push_coalesce
-        let image = ev.frame_image.map(|img| VIEW_PROCESS.on_frame_image(img));
+        let image = ev.frame_image.map(|img| (VIEW_PROCESS.on_frame_image(&img), img));
         let args = crate::view_process::raw_events::RawFrameRenderedArgs::now(window_id, ev.frame, image);
         self.notify_event(crate::view_process::raw_events::RAW_FRAME_RENDERED_EVENT.new_update(args), observer);
     }

--- a/crates/zng-app/src/running.rs
+++ b/crates/zng-app/src/running.rs
@@ -368,7 +368,7 @@ impl<E: AppExtension> RunningApp<E> {
                 if let Some(handle) = VIEW_PROCESS.on_image_decoded(&img) {
                     let args = RawImageDecodedArgs::now(handle, img);
                     self.notify_event(RAW_IMAGE_DECODED_EVENT.new_update(args), observer);
-                 }else {
+                } else {
                     tracing::warn!("received unknown image metadata {:?} ({:?}), ignoring", img.meta.id, img.meta.size);
                 }
             }

--- a/crates/zng-app/src/view_process.rs
+++ b/crates/zng-app/src/view_process.rs
@@ -15,14 +15,10 @@ use crate::{
     window::{MonitorId, WindowId},
 };
 
-use parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock};
+use parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard};
 use zng_app_context::app_local;
-use zng_layout::unit::PxDensity2d;
-use zng_layout::unit::{DipPoint, DipRect, DipSideOffsets, DipSize, Factor, Px, PxPoint, PxRect, PxSize};
-use zng_task::{
-    SignalOnce,
-    channel::{self, ChannelError, IpcBytes, IpcReceiver},
-};
+use zng_layout::unit::{DipPoint, DipRect, DipSideOffsets, DipSize, Factor, Px, PxPoint, PxRect};
+use zng_task::channel::{self, ChannelError, IpcBytes, IpcReceiver, Receiver};
 use zng_txt::Txt;
 use zng_var::{ResponderVar, Var, VarHandle};
 use zng_view_api::{
@@ -31,10 +27,7 @@ use zng_view_api::{
     dialog::{FileDialog, FileDialogResponse, MsgDialog, MsgDialogResponse, Notification, NotificationResponse},
     drag_drop::{DragDropData, DragDropEffect, DragDropError},
     font::{FontOptions, IpcFontBytes},
-    image::{
-        ColorType, ImageDecoded, ImageEncodeId, ImageEntryKind, ImageEntryMetadata, ImageMaskMode, ImageMetadata, ImageRequest,
-        ImageTextureId,
-    },
+    image::{ImageDecoded, ImageEncodeId, ImageEncodeRequest, ImageMaskMode, ImageMetadata, ImageRequest, ImageTextureId},
     window::{
         CursorIcon, FocusIndicator, FrameRequest, FrameUpdateRequest, HeadlessOpenData, HeadlessRequest, RenderMode, ResizeDirection,
         VideoMode, WindowButton, WindowRequest, WindowStateAll,
@@ -42,8 +35,7 @@ use zng_view_api::{
 };
 
 pub(crate) use zng_view_api::{
-    Controller, image::ImageEncodeRequest as ApiImageEncodeRequest, raw_input::InputDeviceId as ApiDeviceId,
-    window::MonitorId as ApiMonitorId, window::WindowId as ApiWindowId,
+    Controller, raw_input::InputDeviceId as ApiDeviceId, window::MonitorId as ApiMonitorId, window::WindowId as ApiWindowId,
 };
 use zng_view_api::{
     clipboard::{ClipboardData, ClipboardError, ClipboardType},
@@ -67,8 +59,7 @@ struct ViewProcessService {
 
     info: ViewProcessInfo,
 
-    loading_images: Vec<sync::Weak<RwLock<ViewImageData>>>,
-    frame_images: Vec<sync::Weak<RwLock<ViewImageData>>>,
+    loading_images: Vec<sync::Weak<ViewImageHandleData>>,
     encoding_images: Vec<EncodeRequest>,
 
     pending_frames: usize,
@@ -181,110 +172,67 @@ impl VIEW_PROCESS {
 
     /// Send an image for decoding.
     ///
-    /// This function returns immediately, the [`ViewImage`] will update when
-    /// [`Event::ImageMetadataDecoded`], [`Event::ImageDecoded`] and [`Event::ImageDecodeError`] events are received.
+    /// This function returns immediately, the handle must be held and compared with the [`RAW_IMAGE_METADATA_DECODED_EVENT`],
+    /// [`RAW_IMAGE_DECODED_EVENT`] and [`RAW_IMAGE_DECODE_ERROR_EVENT`] events to receive the data.
     ///
-    /// [`Event::ImageMetadataDecoded`]: zng_view_api::Event::ImageMetadataDecoded
-    /// [`Event::ImageDecoded`]: zng_view_api::Event::ImageDecoded
-    /// [`Event::ImageDecodeError`]: zng_view_api::Event::ImageDecodeError
-    pub fn add_image(&self, request: ImageRequest<IpcBytes>) -> Result<ViewImage> {
+    /// [`RAW_IMAGE_METADATA_DECODED_EVENT`]: crate::view_process::raw_events::RAW_IMAGE_METADATA_DECODED_EVENT
+    /// [`RAW_IMAGE_DECODED_EVENT`]: crate::view_process::raw_events::RAW_IMAGE_DECODED_EVENT
+    /// [`RAW_IMAGE_DECODE_ERROR_EVENT`]: crate::view_process::raw_events::RAW_IMAGE_DECODE_ERROR_EVENT
+    pub fn add_image(&self, request: ImageRequest<IpcBytes>) -> Result<ViewImageHandle> {
         let mut app = self.write();
-
-        // decoded events will override this, but we try to set some metadata in advance,
-        // in particular `parent` can be used immediately by the IMAGES service.
-        let mut view_data = ViewImageData {
-            id: None,
-            parent: request.parent.clone(),
-            app_id: APP.id(),
-            generation: app.process.generation(),
-            size: PxSize::zero(),
-            partial_size: PxSize::zero(),
-            density: None,
-            original_color_type: ColorType::new(Txt::from(""), 0, 0),
-            is_opaque: false,
-            partial_pixels: None,
-            pixels: None,
-            is_mask: request.mask.is_some(),
-            done_signal: SignalOnce::new(),
-        };
-        match &request.format {
-            zng_view_api::image::ImageDataFormat::Bgra8 {
-                size,
-                density,
-                original_color_type,
-            } => {
-                view_data.density = *density;
-                view_data.original_color_type = original_color_type.clone();
-                if request.downscale.is_none() && request.data.len() == size.width.0 as usize * size.height.0 as usize * 4 {
-                    view_data.size = *size;
-                    view_data.pixels = Some(Ok(request.data.clone()));
-                }
-            }
-            zng_view_api::image::ImageDataFormat::A8 { size } => {
-                if request.downscale.is_none() && request.data.len() == size.width.0 as usize * size.height.0 as usize {
-                    view_data.size = *size;
-                    view_data.pixels = Some(Ok(request.data.clone()));
-                }
-            }
-            _ => {}
-        }
 
         let id = app.process.add_image(request)?;
 
-        view_data.id = Some(id);
-        let img = ViewImage(Arc::new(RwLock::new(view_data)));
-        app.loading_images.push(Arc::downgrade(&img.0));
+        let handle = Arc::new((APP.id().unwrap(), app.process.generation(), id));
+        app.loading_images.push(Arc::downgrade(&handle));
 
-        Ok(img)
+        Ok(ViewImageHandle(Some(handle)))
     }
 
     /// Starts sending an image for *progressive* decoding.
     ///
-    /// This function returns immediately, the [`ViewImage`] will update when
-    /// [`Event::ImageMetadataDecoded`], [`Event::ImagePartiallyDecoded`],
-    /// [`Event::ImageDecoded`] and [`Event::ImageDecodeError`] events are received.
+    /// This function returns immediately, the handle must be held and compared with the [`RAW_IMAGE_METADATA_DECODED_EVENT`],
+    /// [`RAW_IMAGE_DECODED_EVENT`] and [`RAW_IMAGE_DECODE_ERROR_EVENT`] events to receive the data.
     ///
-    /// [`Event::ImageMetadataDecoded`]: zng_view_api::Event::ImageMetadataDecoded
-    /// [`Event::ImageDecoded`]: zng_view_api::Event::ImageDecoded
-    /// [`Event::ImageDecodeError`]: zng_view_api::Event::ImageDecodeError
-    /// [`Event::ImagePartiallyDecoded`]: zng_view_api::Event::ImagePartiallyDecoded
-    pub fn add_image_pro(&self, request: ImageRequest<IpcReceiver<IpcBytes>>) -> Result<ViewImage> {
+    /// [`RAW_IMAGE_METADATA_DECODED_EVENT`]: crate::view_process::raw_events::RAW_IMAGE_METADATA_DECODED_EVENT
+    /// [`RAW_IMAGE_DECODED_EVENT`]: crate::view_process::raw_events::RAW_IMAGE_DECODED_EVENT
+    /// [`RAW_IMAGE_DECODE_ERROR_EVENT`]: crate::view_process::raw_events::RAW_IMAGE_DECODE_ERROR_EVENT
+    pub fn add_image_pro(&self, request: ImageRequest<IpcReceiver<IpcBytes>>) -> Result<ViewImageHandle> {
         let mut app = self.write();
-
-        // decoded events will override this, but we try to set some metadata in advance,
-        // in particular `parent` can be used immediately by the IMAGES service.
-        let mut view_data = ViewImageData {
-            id: None,
-            parent: request.parent.clone(),
-            app_id: APP.id(),
-            generation: app.process.generation(),
-            size: PxSize::zero(),
-            partial_size: PxSize::zero(),
-            density: None,
-            original_color_type: ColorType::new(Txt::from(""), 0, 0),
-            is_opaque: false,
-            partial_pixels: None,
-            pixels: None,
-            is_mask: false,
-            done_signal: SignalOnce::new(),
-        };
-        if let zng_view_api::image::ImageDataFormat::Bgra8 {
-            density,
-            original_color_type,
-            ..
-        } = &request.format
-        {
-            view_data.density = *density;
-            view_data.original_color_type = original_color_type.clone();
-        }
 
         let id = app.process.add_image_pro(request)?;
 
-        view_data.id = Some(id);
-        let img = ViewImage(Arc::new(RwLock::new(view_data)));
-        app.loading_images.push(Arc::downgrade(&img.0));
+        let handle = Arc::new((APP.id().unwrap(), app.process.generation(), id));
+        app.loading_images.push(Arc::downgrade(&handle));
 
-        Ok(img)
+        Ok(ViewImageHandle(Some(handle)))
+    }
+
+    /// Starts encoding an image.
+    ///
+    /// The returned channel will update once with the result.
+    pub fn encode_image(&self, request: ImageEncodeRequest) -> Receiver<std::result::Result<IpcBytes, EncodeError>> {
+        let (sender, receiver) = channel::bounded(1);
+
+        if request.id == ImageId::INVALID {
+            let mut app = VIEW_PROCESS.write();
+
+            match app.process.encode_image(request) {
+                Ok(r) => {
+                    app.encoding_images.push(EncodeRequest {
+                        task_id: r,
+                        listener: sender,
+                    });
+                }
+                Err(_) => {
+                    let _ = sender.send_blocking(Err(EncodeError::Disconnected));
+                }
+            }
+        } else {
+            let _ = sender.send_blocking(Err(EncodeError::Dummy));
+        }
+
+        receiver
     }
 
     /// View-process clipboard methods.
@@ -392,7 +340,6 @@ impl VIEW_PROCESS {
             monitor_ids: HashMap::default(),
             loading_images: vec![],
             encoding_images: vec![],
-            frame_images: vec![],
             pending_frames: 0,
             message_dialogs: vec![],
             file_dialogs: vec![],
@@ -459,14 +406,14 @@ impl VIEW_PROCESS {
         (surf, data)
     }
 
-    pub(super) fn on_image_metadata(&self, meta: ImageMetadata) -> Option<ViewImage> {
+    pub(super) fn on_image_metadata(&self, meta: &ImageMetadata) -> Option<ViewImageHandle> {
         let mut app = self.write();
 
         let mut found = None;
         app.loading_images.retain(|i| {
-            if let Some(img) = i.upgrade() {
-                if found.is_none() && img.read().id == Some(meta.id) {
-                    found = Some(img);
+            if let Some(h) = i.upgrade() {
+                if found.is_none() && h.2 == meta.id {
+                    found = Some(h);
                 }
                 // retain
                 true
@@ -475,75 +422,58 @@ impl VIEW_PROCESS {
             }
         });
 
-        if let Some(found) = found {
-            {
-                let mut img = found.write();
-                img.size = meta.size;
-                img.density = meta.density;
-                img.original_color_type = meta.original_color_type;
-                img.is_mask = meta.is_mask;
-                img.parent = meta.parent;
-            }
-            Some(ViewImage(found))
-        } else if let Some(m) = meta.parent {
-            // assume parent is still in use and start tracking this ViewImage
+        // Best effort avoid tracking handles already dropped,
+        // the VIEW_PROCESS handles all image requests so we
+        // can track all primary requests, only entry images are send without
+        // knowing so we can skip all not found without parent.
+        //
+        // This could potentially restart tracking an entry that was dropped, but
+        // all that does is generate a no-op event and a second `forget_image` requests for the view-process.
 
-            let i = ViewImage(Arc::new(RwLock::new(ViewImageData {
-                id: Some(meta.id),
-                parent: Some(m),
-                app_id: APP.id(),
-                generation: app.process.generation(),
-                size: meta.size,
-                partial_size: PxSize::zero(),
-                density: meta.density,
-                original_color_type: meta.original_color_type,
-                is_opaque: false,
-                partial_pixels: None,
-                pixels: None,
-                is_mask: meta.is_mask,
-                done_signal: SignalOnce::new(),
-            })));
-            app.loading_images.push(Arc::downgrade(&i.0));
+        if found.is_none() && meta.parent.is_some() {
+            // start tracking entry image
 
-            Some(i)
-        } else {
-            // image discarded or unknown
-            None
+            let handle = Arc::new((APP.id().unwrap(), app.process.generation(), meta.id));
+            app.loading_images.push(Arc::downgrade(&handle));
+
+            return Some(ViewImageHandle(Some(handle)));
         }
+
+        found.map(|h| ViewImageHandle(Some(h)))
     }
 
-    pub(super) fn on_image_partially_decoded(&self, data: ImageDecoded) -> Option<ViewImage> {
-        if let Some(img) = self
-            .read()
-            .loading_images
-            .iter()
-            .filter_map(|i| i.upgrade())
-            .find(|i| i.read().id == Some(data.meta.id))
-        {
-            {
-                let mut img = img.write();
-                img.partial_size = data.meta.size;
-                img.density = data.meta.density;
-                img.original_color_type = data.meta.original_color_type;
-                img.is_opaque = data.is_opaque;
-                img.partial_pixels = Some(data.pixels);
-                img.is_mask = data.meta.is_mask;
-                img.parent = data.meta.parent
+    pub(super) fn on_image_decoded(&self, data: &ImageDecoded) -> Option<ViewImageHandle> {
+        let mut app = self.write();
+
+        // retain loading handle only for partial decode, cleanup for full decode.
+        //
+        // All valid not dropped requests are already in `loading_images` because they are
+        // either primary requests or are entries (view-process always sends metadata decoded first for entries).
+
+        let mut found = None;
+        app.loading_images.retain(|i| {
+            if let Some(h) = i.upgrade() {
+                if found.is_none() && h.2 == data.meta.id {
+                    found = Some(h);
+                    return data.partial.is_some();
+                }
+                true
+            } else {
+                false
             }
-            Some(ViewImage(img))
-        } else {
-            None
-        }
+        });
+
+        found.map(|h| ViewImageHandle(Some(h)))
     }
 
-    pub(super) fn on_image_decoded(&self, data: ImageDecoded) -> Option<ViewImage> {
+    pub(super) fn on_image_error(&self, id: ImageId) -> Option<ViewImageHandle> {
         let mut app = self.write();
 
         let mut found = None;
         app.loading_images.retain(|i| {
-            if let Some(img) = i.upgrade() {
-                if found.is_none() && img.read().id == Some(data.meta.id) {
-                    found = Some(img);
+            if let Some(h) = i.upgrade() {
+                if found.is_none() && h.2 == id {
+                    found = Some(h);
                     return false;
                 }
                 true
@@ -552,52 +482,9 @@ impl VIEW_PROCESS {
             }
         });
 
-        if let Some(img) = found {
-            {
-                let mut img = img.write();
-                img.size = data.meta.size;
-                img.partial_size = data.meta.size;
-                img.density = data.meta.density;
-                img.original_color_type = data.meta.original_color_type;
-                img.is_opaque = data.is_opaque;
-                img.pixels = Some(Ok(data.pixels));
-                img.partial_pixels = None;
-                img.is_mask = data.meta.is_mask;
-                img.parent = data.meta.parent;
-                img.done_signal.set();
-            }
-            Some(ViewImage(img))
-        } else {
-            None
-        }
-    }
+        // error images should already be removed from view-process, handle will request a removal anyway
 
-    pub(super) fn on_image_error(&self, id: ImageId, error: Txt) -> Option<ViewImage> {
-        let mut app = self.write();
-
-        let mut found = None;
-        app.loading_images.retain(|i| {
-            if let Some(img) = i.upgrade() {
-                if found.is_none() && img.read().id == Some(id) {
-                    found = Some(img);
-                    return false;
-                }
-                true
-            } else {
-                false
-            }
-        });
-
-        if let Some(img) = found {
-            {
-                let mut img = img.write();
-                img.pixels = Some(Err(error));
-                img.done_signal.set();
-            }
-            Some(ViewImage(img))
-        } else {
-            None
-        }
+        found.map(|h| ViewImageHandle(Some(h)))
     }
 
     pub(crate) fn on_frame_rendered(&self, _id: WindowId) {
@@ -605,33 +492,8 @@ impl VIEW_PROCESS {
         vp.pending_frames = vp.pending_frames.saturating_sub(1);
     }
 
-    pub(crate) fn on_frame_image(&self, data: ImageDecoded) -> ViewImage {
-        ViewImage(Arc::new(RwLock::new(ViewImageData {
-            app_id: APP.id(),
-            id: Some(data.meta.id),
-            parent: data.meta.parent,
-            generation: self.generation(),
-            size: data.meta.size,
-            partial_size: data.meta.size,
-            density: data.meta.density,
-            original_color_type: data.meta.original_color_type,
-            is_opaque: data.is_opaque,
-            partial_pixels: None,
-            pixels: Some(Ok(data.pixels)),
-            is_mask: data.meta.is_mask,
-            done_signal: SignalOnce::new_set(),
-        })))
-    }
-
-    pub(super) fn on_frame_image_ready(&self, id: ImageId) -> Option<ViewImage> {
-        let mut app = self.write();
-
-        // cleanup
-        app.frame_images.retain(|i| i.strong_count() > 0);
-
-        let i = app.frame_images.iter().position(|i| i.upgrade().unwrap().read().id == Some(id));
-
-        i.map(|i| ViewImage(app.frame_images.swap_remove(i).upgrade().unwrap()))
+    pub(crate) fn on_frame_image(&self, data: &ImageDecoded) -> ViewImageHandle {
+        ViewImageHandle(Some(Arc::new((APP.id().unwrap(), self.generation(), data.meta.id))))
     }
 
     pub(super) fn on_image_encoded(&self, task_id: ImageEncodeId, data: IpcBytes) {
@@ -858,12 +720,11 @@ impl ViewWindow {
     }
 
     /// Set the window icon.
-    pub fn set_icon(&self, icon: Option<&ViewImage>) -> Result<()> {
+    pub fn set_icon(&self, icon: Option<&ViewImageHandle>) -> Result<()> {
         self.0.call(|id, p| {
-            if let Some(icon) = icon {
-                let icon = icon.0.read();
-                if p.generation() == icon.generation {
-                    p.set_icon(id, icon.id)
+            if let Some(icon) = icon.and_then(|i| i.0.as_ref()) {
+                if p.generation() == icon.1 {
+                    p.set_icon(id, Some(icon.2))
                 } else {
                     Err(ChannelError::disconnected())
                 }
@@ -884,12 +745,11 @@ impl ViewWindow {
     ///
     /// The `hotspot` value is an exact point in the image that is the mouse position. This value is only used if
     /// the image format does not contain a hotspot.
-    pub fn set_cursor_image(&self, cursor: Option<&ViewImage>, hotspot: PxPoint) -> Result<()> {
+    pub fn set_cursor_image(&self, cursor: Option<&ViewImageHandle>, hotspot: PxPoint) -> Result<()> {
         self.0.call(|id, p| {
-            if let Some(cur) = cursor {
-                let cur = cur.0.read();
-                if p.generation() == cur.generation {
-                    p.set_cursor_image(id, cur.id.map(|img| zng_view_api::window::CursorImage::new(img, hotspot)))
+            if let Some(cur) = cursor.and_then(|i| i.0.as_ref()) {
+                if p.generation() == cur.1 {
+                    p.set_cursor_image(id, Some(zng_view_api::window::CursorImage::new(cur.2, hotspot)))
                 } else {
                     Err(ChannelError::disconnected())
                 }
@@ -1205,30 +1065,36 @@ impl ViewRenderer {
     /// Use an image resource in the window renderer.
     ///
     /// Returns the image texture ID.
-    pub fn use_image(&self, image: &ViewImage) -> Result<ImageTextureId> {
+    pub fn use_image(&self, image: &ViewImageHandle) -> Result<ImageTextureId> {
         self.call(|id, p| {
-            let image = image.0.read();
-            if p.generation() == image.generation {
-                p.use_image(id, image.id.unwrap_or(ImageId::INVALID))
+            if let Some(img) = &image.0 {
+                if p.generation() == img.1 {
+                    p.use_image(id, img.2)
+                } else {
+                    Err(ChannelError::disconnected())
+                }
             } else {
-                Err(ChannelError::disconnected())
+                Ok(ImageTextureId::INVALID)
             }
         })
     }
 
     /// Replace the image resource in the window renderer.
     ///
-    /// The new `image_id` must represent an image with same dimensions and format as the previous. If the
+    /// The new `image` handle must represent an image with same dimensions and format as the previous. If the
     /// image cannot be updated an error is logged and `false` is returned.
     ///
     /// The `dirty_rect` can be set to optimize texture upload to the GPU, if not set the entire image region updates.
-    pub fn update_image_use(&mut self, tex_id: ImageTextureId, image: &ViewImage, dirty_rect: Option<PxRect>) -> Result<bool> {
+    pub fn update_image_use(&mut self, tex_id: ImageTextureId, image: &ViewImageHandle, dirty_rect: Option<PxRect>) -> Result<bool> {
         self.call(|id, p| {
-            let image = image.0.read();
-            if p.generation() == image.generation {
-                p.update_image_use(id, tex_id, image.id.unwrap_or(ImageId::INVALID), dirty_rect)
+            if let Some(img) = &image.0 {
+                if p.generation() == img.1 {
+                    p.update_image_use(id, tex_id, img.2, dirty_rect)
+                } else {
+                    Err(ChannelError::disconnected())
+                }
             } else {
-                Err(ChannelError::disconnected())
+                Ok(false)
             }
         })
     }
@@ -1269,7 +1135,7 @@ impl ViewRenderer {
     }
 
     /// Create a new image resource from the current rendered frame.
-    pub fn frame_image(&self, mask: Option<ImageMaskMode>) -> Result<ViewImage> {
+    pub fn frame_image(&self, mask: Option<ImageMaskMode>) -> Result<ViewImageHandle> {
         if let Some(c) = self.0.upgrade() {
             let id = c.call(|id, p| p.frame_image(id, mask))?;
             Ok(Self::add_frame_image(c.app_id, id))
@@ -1279,7 +1145,7 @@ impl ViewRenderer {
     }
 
     /// Create a new image resource from a selection of the current rendered frame.
-    pub fn frame_image_rect(&self, rect: PxRect, mask: Option<ImageMaskMode>) -> Result<ViewImage> {
+    pub fn frame_image_rect(&self, rect: PxRect, mask: Option<ImageMaskMode>) -> Result<ViewImageHandle> {
         if let Some(c) = self.0.upgrade() {
             let id = c.call(|id, p| p.frame_image_rect(id, rect, mask))?;
             Ok(Self::add_frame_image(c.app_id, id))
@@ -1288,31 +1154,15 @@ impl ViewRenderer {
         }
     }
 
-    fn add_frame_image(app_id: AppId, id: ImageId) -> ViewImage {
+    fn add_frame_image(app_id: AppId, id: ImageId) -> ViewImageHandle {
         if id == ImageId::INVALID {
-            ViewImage::dummy(None)
+            ViewImageHandle::dummy()
         } else {
             let mut app = VIEW_PROCESS.handle_write(app_id);
-            let img = ViewImage(Arc::new(RwLock::new(ViewImageData {
-                app_id: Some(app_id),
-                id: Some(id),
-                parent: None,
-                generation: app.process.generation(),
-                size: PxSize::zero(),
-                partial_size: PxSize::zero(),
-                density: None,
-                original_color_type: ColorType::new(Txt::from(""), 0, 0),
-                is_opaque: false,
-                partial_pixels: None,
-                pixels: None,
-                is_mask: false,
-                done_signal: SignalOnce::new(),
-            })));
+            let handle = Arc::new((APP.id().unwrap(), app.process.generation(), id));
+            app.loading_images.push(Arc::downgrade(&handle));
 
-            app.loading_images.push(Arc::downgrade(&img.0));
-            app.frame_images.push(Arc::downgrade(&img.0));
-
-            img
+            ViewImageHandle(Some(handle))
         }
     }
 
@@ -1362,272 +1212,75 @@ impl ViewRenderer {
     }
 }
 
+type ViewImageHandleData = (AppId, ViewProcessGen, ImageId);
+
 /// Handle to an image loading or loaded in the View Process.
 ///
 /// The image is disposed when all clones of the handle are dropped.
 #[must_use = "the image is disposed when all clones of the handle are dropped"]
-#[derive(Clone)]
-pub struct ViewImage(Arc<RwLock<ViewImageData>>);
-impl PartialEq for ViewImage {
+#[derive(Clone, Debug)]
+pub struct ViewImageHandle(Option<Arc<ViewImageHandleData>>);
+impl PartialEq for ViewImageHandle {
     fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.0, &other.0)
-    }
-}
-impl Eq for ViewImage {}
-impl std::hash::Hash for ViewImage {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        let ptr = Arc::as_ptr(&self.0) as usize;
-        ptr.hash(state)
-    }
-}
-impl fmt::Debug for ViewImage {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ViewImage")
-            .field("loaded", &self.is_loaded())
-            .field("error", &self.error())
-            .field("size", &self.size())
-            .field("density", &self.density())
-            .field("original_color_type", &self.original_color_type())
-            .field("is_opaque", &self.is_opaque())
-            .field("is_mask", &self.is_mask())
-            .field("generation", &self.generation())
-            .finish_non_exhaustive()
-    }
-}
-
-struct ViewImageData {
-    app_id: Option<AppId>,
-    id: Option<ImageId>,
-    generation: ViewProcessGen,
-
-    size: PxSize,
-    partial_size: PxSize,
-    density: Option<PxDensity2d>,
-    is_mask: bool,
-    original_color_type: ColorType,
-
-    partial_pixels: Option<IpcBytes>,
-    pixels: Option<std::result::Result<IpcBytes, Txt>>,
-    is_opaque: bool,
-
-    parent: Option<ImageEntryMetadata>,
-
-    done_signal: SignalOnce,
-}
-impl Drop for ViewImageData {
-    fn drop(&mut self) {
-        if let Some(id) = self.id {
-            let app_id = self.app_id.unwrap();
-            if let Some(app) = APP.id() {
-                if app_id != app {
-                    tracing::error!("image from app `{:?}` dropped in app `{:?}`", app_id, app);
-                }
-
-                if VIEW_PROCESS.is_available() && VIEW_PROCESS.generation() == self.generation {
-                    let _ = VIEW_PROCESS.write().process.forget_image(id);
-                }
-            }
+        match (&self.0, &other.0) {
+            (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+            (None, None) => true,
+            _ => false,
         }
     }
 }
-
-impl ViewImage {
-    /// Image id.
-    pub fn id(&self) -> Option<ImageId> {
-        self.0.read().id
+impl Eq for ViewImageHandle {}
+impl ViewImageHandle {
+    /// New handle to nothing.
+    pub fn dummy() -> Self {
+        ViewImageHandle(None)
     }
 
-    /// Kind of image container entry this image was decoded from.
-    pub fn entry_kind(&self) -> ImageEntryKind {
-        self.0
-            .read()
-            .parent
-            .as_ref()
-            .map(|p| p.kind.clone())
-            .unwrap_or(ImageEntryKind::Page)
-    }
-
-    /// Image this one belongs too.
-    ///
-    /// This image will be listed on the parent `entries`.
-    pub fn entry_parent(&self) -> Option<ImageId> {
-        self.0.read().parent.as_ref().map(|p| p.parent)
-    }
-
-    /// Position of this image as an entry in [`entry_parent`].
-    ///
-    /// [`entry_parent`]: Self::entry_parent
-    pub fn entry_index(&self) -> usize {
-        self.0.read().parent.as_ref().map(|p| p.index).unwrap_or(0)
-    }
-
-    /// If the image does not actually exists in the view-process.
+    /// Is handle to nothing.
     pub fn is_dummy(&self) -> bool {
-        self.0.read().id.is_none()
+        self.0.is_none()
     }
 
-    /// Returns `true` if the image has successfully decoded.
-    pub fn is_loaded(&self) -> bool {
-        self.0.read().pixels.as_ref().map(|r| r.is_ok()).unwrap_or(false)
-    }
-
-    /// Returns `true` if the image is progressively decoding and has partially decoded.
-    pub fn is_partially_loaded(&self) -> bool {
-        self.0.read().partial_pixels.is_some()
-    }
-
-    /// if [`error`] is `Some`.
+    /// Image ID.
     ///
-    /// [`error`]: Self::error
-    pub fn is_error(&self) -> bool {
-        self.0.read().pixels.as_ref().map(|r| r.is_err()).unwrap_or(false)
+    /// Is [`ImageId::INVALID`] for dummy.
+    pub fn image_id(&self) -> ImageId {
+        self.0.as_ref().map(|h| h.2).unwrap_or(ImageId::INVALID)
     }
 
-    /// Returns the load error if one happened.
-    pub fn error(&self) -> Option<Txt> {
-        self.0.read().pixels.as_ref().and_then(|s| s.as_ref().err().cloned())
-    }
-
-    /// Pixel size of the image after it finishes loading.
+    /// Application that requested this image.
     ///
-    /// Note that this value is set as soon as the header finishes decoding, but the [`pixels`] will
-    /// only be set after it the entire image decodes.
+    /// Images can only be used in the same app.
     ///
-    /// If the view-process implements progressive decoding you can use [`partial_size`] and [`partial_pixels`]
-    /// to use the partially decoded image top rows as it decodes.
-    ///
-    /// [`pixels`]: Self::pixels
-    /// [`partial_size`]: Self::partial_size
-    /// [`partial_pixels`]: Self::partial_pixels
-    pub fn size(&self) -> PxSize {
-        self.0.read().size
-    }
-
-    /// Size of [`partial_pixels`].
-    ///
-    /// Can be different from [`size`] if the image is progressively decoding.
-    ///
-    /// [`size`]: Self::size
-    /// [`partial_pixels`]: Self::partial_pixels
-    pub fn partial_size(&self) -> Option<PxSize> {
-        let r = self.0.read();
-        if r.partial_pixels.is_some() { Some(r.partial_size) } else { None }
-    }
-
-    /// Returns the pixel density metadata associated with the image, or `None` if not loaded or error or no
-    /// metadata provided by decoder.
-    pub fn density(&self) -> Option<PxDensity2d> {
-        self.0.read().density
-    }
-
-    /// Image color type before it was converted to BGRA8 or A8.
-    pub fn original_color_type(&self) -> ColorType {
-        self.0.read().original_color_type.clone()
-    }
-
-    /// Returns if the image is fully opaque.
-    pub fn is_opaque(&self) -> bool {
-        self.0.read().is_opaque
-    }
-
-    /// Returns if the image is a single channel mask (A8).
-    pub fn is_mask(&self) -> bool {
-        self.0.read().is_mask
-    }
-
-    /// Reference the partially decoded pixels if the image is progressively decoding
-    /// and has not finished decoding.
-    ///
-    /// Format is BGRA8 for normal images or A8 if [`is_mask`].
-    ///
-    /// [`is_mask`]: Self::is_mask
-    pub fn partial_pixels(&self) -> Option<IpcBytes> {
-        self.0.read().partial_pixels.clone()
-    }
-
-    /// Reference the decoded pixels of image.
-    ///
-    /// Returns `None` until the image is fully loaded. Use [`partial_pixels`] to copy
-    /// partially decoded bytes.
-    ///
-    /// Format is pre-multiplied BGRA8 for normal images or A8 if [`is_mask`].
-    ///
-    /// [`is_mask`]: Self::is_mask
-    ///
-    /// [`partial_pixels`]: Self::partial_pixels
-    pub fn pixels(&self) -> Option<IpcBytes> {
-        self.0.read().pixels.as_ref().and_then(|r| r.as_ref().ok()).cloned()
-    }
-
-    /// Returns the app that owns the view-process that is handling this image.
+    /// Is `None` for dummy.
     pub fn app_id(&self) -> Option<AppId> {
-        self.0.read().app_id
+        self.0.as_ref().map(|h| h.0)
     }
 
-    /// Returns the view-process generation on which the image is loaded.
-    pub fn generation(&self) -> ViewProcessGen {
-        self.0.read().generation
+    /// View-process generation that provided this image.
+    ///
+    /// Images can only be used in the same view-process instance.
+    ///
+    /// Is [`ViewProcessGen::INVALID`] for dummy.
+    pub fn view_process_gen(&self) -> ViewProcessGen {
+        self.0.as_ref().map(|h| h.1).unwrap_or(ViewProcessGen::INVALID)
     }
-
-    /// Creates a [`WeakViewImage`].
-    pub fn downgrade(&self) -> WeakViewImage {
-        WeakViewImage(Arc::downgrade(&self.0))
-    }
-
-    /// Create a dummy image in the loaded or error state.
-    pub fn dummy(error: Option<Txt>) -> Self {
-        ViewImage(Arc::new(RwLock::new(ViewImageData {
-            app_id: None,
-            id: None,
-            generation: ViewProcessGen::INVALID,
-            parent: None,
-            size: PxSize::zero(),
-            partial_size: PxSize::zero(),
-            density: None,
-            original_color_type: ColorType::new(Txt::from(""), 0, 0),
-            is_opaque: true,
-            partial_pixels: None,
-            pixels: if let Some(e) = error {
-                Some(Err(e))
-            } else {
-                Some(Ok(IpcBytes::default()))
-            },
-            is_mask: false,
-            done_signal: SignalOnce::new_set(),
-        })))
-    }
-
-    /// Returns a future that awaits until this image is loaded or encountered an error.
-    pub fn awaiter(&self) -> SignalOnce {
-        self.0.read().done_signal.clone()
-    }
-
-    /// Tries to encode the image.
-    pub async fn encode(&self, request: ImageEncodeRequest) -> std::result::Result<IpcBytes, EncodeError> {
-        self.awaiter().await;
-
-        if let Some(e) = self.error() {
-            return Err(EncodeError::Encode(e));
-        }
-
-        let receiver = {
-            let img = self.0.read();
-            if let Some(id) = img.id {
-                let mut r = ApiImageEncodeRequest::new(id, request.format);
-                r.entries = request.entries;
-                let mut app = VIEW_PROCESS.handle_write(img.app_id.unwrap());
-
-                let task_id = app.process.encode_image(r)?;
-
-                let (sender, receiver) = channel::bounded(1);
-                app.encoding_images.push(EncodeRequest { task_id, listener: sender });
-                receiver
-            } else {
-                return Err(EncodeError::Dummy);
+}
+impl Drop for ViewImageHandle {
+    fn drop(&mut self) {
+        if let Some(h) = self.0.take()
+            && Arc::strong_count(&h) == 1
+            && let Some(app) = APP.id()
+        {
+            if h.0 != app {
+                tracing::error!("image from app `{:?}` dropped in app `{:?}`", h.0, app);
+                return;
             }
-        };
 
-        receiver.recv().await?
+            if VIEW_PROCESS.is_available() && VIEW_PROCESS.generation() == h.1 {
+                let _ = VIEW_PROCESS.write().process.forget_image(h.2);
+            }
+        }
     }
 }
 
@@ -1642,6 +1295,8 @@ pub enum EncodeError {
     /// In a headless-app without renderer all images are dummy because there is no
     /// view-process backend running.
     Dummy,
+    /// Image is still loading, await it first.
+    Loading,
     /// The View-Process disconnected or has not finished initializing yet, try again after [`VIEW_PROCESS_INITED_EVENT`].
     Disconnected,
 }
@@ -1660,6 +1315,7 @@ impl fmt::Display for EncodeError {
         match self {
             EncodeError::Encode(e) => write!(f, "{e}"),
             EncodeError::Dummy => write!(f, "cannot encode dummy image"),
+            EncodeError::Loading => write!(f, "cannot encode, image is still loading"),
             EncodeError::Disconnected => write!(f, "{}", ChannelError::disconnected()),
         }
     }
@@ -1668,17 +1324,19 @@ impl std::error::Error for EncodeError {}
 
 /// Connection to an image loading or loaded in the View Process.
 ///
-/// The image is removed from the View Process cache when all clones of [`ViewImage`] drops, but
+/// The image is removed from the View Process cache when all clones of [`ViewImageHandle`] drops, but
 /// if there is another image pointer holding the image, this weak pointer can be upgraded back
 /// to a strong connection to the image.
+///
+/// Dummy handles never upgrade back.
 #[derive(Clone)]
-pub struct WeakViewImage(sync::Weak<RwLock<ViewImageData>>);
-impl WeakViewImage {
+pub struct WeakViewImageHandle(sync::Weak<ViewImageHandleData>);
+impl WeakViewImageHandle {
     /// Attempt to upgrade the weak pointer to the image to a full image.
     ///
     /// Returns `Some` if the is at least another [`ViewImage`] holding the image alive.
-    pub fn upgrade(&self) -> Option<ViewImage> {
-        self.0.upgrade().map(ViewImage)
+    pub fn upgrade(&self) -> Option<ViewImageHandle> {
+        self.0.upgrade().map(|h| ViewImageHandle(Some(h)))
     }
 }
 
@@ -1723,30 +1381,16 @@ impl ViewClipboard {
     /// Read [`ClipboardType::Image`].
     ///
     /// [`ClipboardType::Image`]: zng_view_api::clipboard::ClipboardType::Image
-    pub fn read_image(&self) -> Result<ClipboardResult<ViewImage>> {
+    pub fn read_image(&self) -> Result<ClipboardResult<ViewImageHandle>> {
         let mut app = VIEW_PROCESS.try_write()?;
         match app.process.read_clipboard(vec![ClipboardType::Image], true)?.map(|mut r| r.pop()) {
             Ok(Some(ClipboardData::Image(id))) => {
                 if id == ImageId::INVALID {
                     Ok(Err(ClipboardError::Other(Txt::from_static("view-process returned invalid image"))))
                 } else {
-                    let img = ViewImage(Arc::new(RwLock::new(ViewImageData {
-                        id: Some(id),
-                        parent: None,
-                        app_id: APP.id(),
-                        generation: app.process.generation(),
-                        size: PxSize::zero(),
-                        partial_size: PxSize::zero(),
-                        density: None,
-                        original_color_type: ColorType::new(Txt::from(""), 0, 0),
-                        is_opaque: false,
-                        partial_pixels: None,
-                        pixels: None,
-                        is_mask: false,
-                        done_signal: SignalOnce::new(),
-                    })));
-                    app.loading_images.push(Arc::downgrade(&img.0));
-                    Ok(Ok(img))
+                    let handle = Arc::new((APP.id().unwrap(), app.process.generation(), id));
+                    app.loading_images.push(Arc::downgrade(&handle));
+                    Ok(Ok(ViewImageHandle(Some(handle))))
                 }
             }
             Err(e) => Ok(Err(e)),
@@ -1757,17 +1401,12 @@ impl ViewClipboard {
     /// Write [`ClipboardType::Image`].
     ///
     /// [`ClipboardType::Image`]: zng_view_api::clipboard::ClipboardType::Image
-    pub fn write_image(&self, img: &ViewImage) -> Result<ClipboardResult<()>> {
-        if img.is_loaded()
-            && let Some(id) = img.id()
-        {
-            return VIEW_PROCESS
-                .try_write()?
-                .process
-                .write_clipboard(vec![ClipboardData::Image(id)])
-                .map(|r| r.map(|_| ()));
-        }
-        Ok(Err(ClipboardError::Other(Txt::from_static("image not loaded"))))
+    pub fn write_image(&self, img: &ViewImageHandle) -> Result<ClipboardResult<()>> {
+        return VIEW_PROCESS
+            .try_write()?
+            .process
+            .write_clipboard(vec![ClipboardData::Image(img.image_id())])
+            .map(|r| r.map(|_| ()));
     }
 
     /// Read [`ClipboardType::Paths`].
@@ -1822,26 +1461,5 @@ impl ViewClipboard {
             .process
             .write_clipboard(vec![ClipboardData::Extension { data_type, data }])
             .map(|r| r.map(|_| ()))
-    }
-}
-
-/// Represent a image encode request.
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct ImageEncodeRequest {
-    /// Optional entries to also encode.
-    ///
-    /// If set encodes the `id` as the first *page* followed by each entry in the order given.
-    pub entries: Vec<(ImageId, ImageEntryKind)>,
-
-    /// Format query, view-process uses [`ImageFormat::matches`] to find the format.
-    ///
-    /// [`ImageFormat::matches`]: zng_view_api::image::ImageFormat::matches
-    pub format: Txt,
-}
-impl ImageEncodeRequest {
-    /// New.
-    pub fn new(format: Txt) -> Self {
-        Self { entries: vec![], format }
     }
 }

--- a/crates/zng-app/src/view_process.rs
+++ b/crates/zng-app/src/view_process.rs
@@ -1284,7 +1284,7 @@ impl Drop for ViewImageHandle {
     }
 }
 
-/// Error returned by [`ViewImage::encode`].
+/// Error returned by [`VIEW_PROCESS::encode_image`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum EncodeError {
@@ -1334,7 +1334,7 @@ pub struct WeakViewImageHandle(sync::Weak<ViewImageHandleData>);
 impl WeakViewImageHandle {
     /// Attempt to upgrade the weak pointer to the image to a full image.
     ///
-    /// Returns `Some` if the is at least another [`ViewImage`] holding the image alive.
+    /// Returns `Some` if the is at least another [`ViewImageHandle`] holding the image alive.
     pub fn upgrade(&self) -> Option<ViewImageHandle> {
         self.0.upgrade().map(|h| ViewImageHandle(Some(h)))
     }

--- a/crates/zng-ext-image/src/render.rs
+++ b/crates/zng-ext-image/src/render.rs
@@ -2,6 +2,7 @@ use std::{any::Any, sync::Arc};
 
 use zng_app::{
     update::{EventUpdate, UPDATES},
+    view_process::ViewImageHandle,
     widget::{
         WIDGET,
         node::{IntoUiNode, UiNode, UiNodeOp, match_node},
@@ -14,7 +15,7 @@ use zng_state_map::{StateId, static_id};
 use zng_var::{IntoVar, Var, WeakVar, var};
 use zng_view_api::{image::ImageMaskMode, window::RenderMode};
 
-use crate::{IMAGES, IMAGES_SV, ImageManager, ImageRenderArgs, ImageSource, ImageVar, ImagesService, Img};
+use crate::{IMAGES, IMAGES_SV, ImageRenderArgs, ImageSource, ImageVar, ImagesService, Img};
 
 impl ImagesService {
     fn render<N, R>(&mut self, mask: Option<ImageMaskMode>, render: N) -> ImageVar
@@ -22,7 +23,7 @@ impl ImagesService {
         N: FnOnce() -> R + Send + Sync + 'static,
         R: ImageRenderWindowRoot,
     {
-        let result = var(Img::new_none(None));
+        let result = var(Img::new_loading(ViewImageHandle::dummy()));
         let windows = self.render.windows();
         self.render_img(
             mask,
@@ -41,7 +42,7 @@ impl ImagesService {
         N: FnOnce() -> UiNode + Send + Sync + 'static,
     {
         let scale_factor = scale_factor.into();
-        let result = var(Img::new_none(None));
+        let result = var(Img::new_loading(ViewImageHandle::dummy()));
         let windows = self.render.windows();
         self.render_img(
             mask,
@@ -213,15 +214,14 @@ impl IMAGES_WINDOW {
     }
 }
 
-impl ImageManager {
+impl ImagesService {
     /// AppExtension::update
     pub(super) fn update_render(&mut self) {
-        let mut images = IMAGES_SV.write();
+        // update render
+        if !self.render.active.is_empty() {
+            let windows = self.render.windows();
 
-        if !images.render.active.is_empty() {
-            let windows = images.render.windows();
-
-            images.render.active.retain(|r| {
+            self.render.active.retain(|r| {
                 let mut retain = false;
                 if let Some(img) = r.image.upgrade() {
                     retain = img.with(Img::is_loading) || r.retain.get();
@@ -234,11 +234,10 @@ impl ImageManager {
                 retain
             });
         }
+        if !self.render.requests.is_empty() {
+            let windows = self.render.windows();
 
-        if !images.render.requests.is_empty() {
-            let windows = images.render.windows();
-
-            for req in images.render.requests.drain(..) {
+            for req in self.render.requests.drain(..) {
                 if let Some(img) = req.image.upgrade() {
                     let windows_in = windows.clone_boxed();
                     windows.open_headless_window(Box::new(move || {
@@ -265,11 +264,10 @@ impl ImageManager {
     }
 
     /// AppExtension::event_preview
-    pub(super) fn event_preview_render(&mut self, update: &EventUpdate) {
-        let imgs = IMAGES_SV.read();
-        if !imgs.render.active.is_empty()
-            && let Some((id, img)) = imgs.render.windows().on_frame_image_ready(update)
-            && let Some(a) = imgs.render.active.iter().find(|a| a.window_id == id)
+    pub(super) fn event_preview_render(&self, update: &EventUpdate) {
+        if !self.render.active.is_empty()
+            && let Some((id, img)) = self.render.windows().on_frame_image_ready(update)
+            && let Some(a) = self.render.active.iter().find(|a| a.window_id == id)
             && let Some(img_var) = a.image.upgrade()
         {
             img_var.set(img.clone());

--- a/crates/zng-ext-image/src/types.rs
+++ b/crates/zng-ext-image/src/types.rs
@@ -123,9 +123,6 @@ struct ImgMut {
 
 /// State of an [`ImageVar`].
 ///
-/// This value is a shared reference to the image, on view-process updates the image data is mutated immediately.
-/// To ensure that variable updates propagate the new value the [`IMAGES`] service calls [`Img::update`] on the value.
-///
 /// [`IMAGES`]: crate::IMAGES
 #[derive(Debug, Clone)]
 pub struct Img {

--- a/crates/zng-ext-svg/src/lib.rs
+++ b/crates/zng-ext-svg/src/lib.rs
@@ -88,7 +88,7 @@ fn load(max_decoded_len: ByteLength, data: SvgData, downscale: Option<ImageDowns
             }
 
             if size.width() as usize * size.height() as usize * 4 > max_decoded_len.bytes() {
-                let img = Img::dummy(Some(formatx!("cannot render svg, would exceed max {max_decoded_len} allowed")));
+                let img = Img::new_empty(formatx!("cannot render svg, would exceed max {max_decoded_len} allowed"));
                 return ImageSource::Image(zng_var::const_var(img));
             }
 

--- a/crates/zng-ext-window/src/service.rs
+++ b/crates/zng-ext-window/src/service.rs
@@ -55,10 +55,7 @@ use crate::{
 use std::any::Any;
 
 #[cfg(feature = "image")]
-use zng_app::view_process::{
-    ViewImage, ViewRenderer,
-    raw_events::{RAW_IMAGE_LOAD_ERROR_EVENT, RAW_IMAGE_LOADED_EVENT},
-};
+use zng_app::view_process::{ViewImageHandle, ViewRenderer};
 
 #[cfg(feature = "image")]
 use zng_ext_image::{ImageRenderWindowRoot, ImageRenderWindowsService, ImageVar, Img};
@@ -68,9 +65,6 @@ use crate::{FRAME_IMAGE_READY_EVENT, FrameCaptureMode, HeadlessMonitor, StartPos
 
 #[cfg(feature = "image")]
 use zng_view_api::image::ImageMaskMode;
-
-#[cfg(feature = "image")]
-use zng_var::WeakVar;
 
 #[cfg(feature = "image")]
 use zng_layout::unit::{Factor, LengthUnits, PxRect};
@@ -104,9 +98,6 @@ pub(super) struct WindowsService {
     focus_request: Option<WindowId>,
     bring_to_top_requests: Vec<WindowId>,
 
-    #[cfg(feature = "image")]
-    frame_images: Vec<WeakVar<Img>>,
-
     loading_deadline: Option<DeadlineHandle>,
     latest_colors_cfg: ColorsConfig,
 
@@ -131,8 +122,6 @@ impl WindowsService {
             close_requests: vec![],
             focus_request: None,
             bring_to_top_requests: vec![],
-            #[cfg(feature = "image")]
-            frame_images: vec![],
             loading_deadline: None,
             latest_colors_cfg: ColorsConfig::default(),
             view_window_tasks: vec![],
@@ -201,25 +190,24 @@ impl WindowsService {
     fn frame_image_impl(
         &mut self,
         window_id: WindowId,
-        action: impl FnOnce(&ViewRenderer) -> std::result::Result<ViewImage, ChannelError>,
+        action: impl FnOnce(&ViewRenderer) -> std::result::Result<ViewImageHandle, ChannelError>,
     ) -> ImageVar {
         if let Some(w) = self.windows_info.get(&window_id) {
             if let Some(r) = &w.view {
                 match action(&r.renderer()) {
-                    Ok(img) => {
-                        let img = Img::new(img);
-                        let img = var(img);
-                        self.frame_images.retain(|i| i.strong_count() > 0);
-                        self.frame_images.push(img.downgrade());
-                        img.read_only()
+                    Ok(handle) => {
+                        use zng_ext_image::IMAGES;
+                        use zng_view_api::image::ImageDecoded;
+
+                        IMAGES.register(None, (handle, ImageDecoded::default())).unwrap()
                     }
-                    Err(_) => var(Img::dummy(Some(formatx!("{}", WindowNotFoundError::new(window_id))))).read_only(),
+                    Err(_) => const_var(Img::new_empty(formatx!("{}", WindowNotFoundError::new(window_id)))),
                 }
             } else {
-                var(Img::dummy(Some(formatx!("window `{window_id}` is headless without renderer")))).read_only()
+                const_var(Img::new_empty(formatx!("window `{window_id}` is headless without renderer")))
             }
         } else {
-            var(Img::dummy(Some(formatx!("{}", WindowNotFoundError::new(window_id))))).read_only()
+            const_var(Img::new_empty(formatx!("{}", WindowNotFoundError::new(window_id))))
         }
     }
 
@@ -1042,24 +1030,6 @@ impl WINDOWS {
         } else if VIEW_PROCESS_INITED_EVENT.has(update) {
             // we skipped request fulfillment until this event.
             UPDATES.update(None);
-        } else {
-            #[cfg(feature = "image")]
-            if let Some(args) = RAW_IMAGE_LOADED_EVENT.on(update).or_else(|| RAW_IMAGE_LOAD_ERROR_EVENT.on(update)) {
-                // update ready frame images.
-                let mut sv = WINDOWS_SV.write();
-                sv.frame_images.retain(|i| {
-                    if let Some(i) = i.upgrade() {
-                        if Some(&args.image) == i.get().view() {
-                            i.update();
-                            false
-                        } else {
-                            true
-                        }
-                    } else {
-                        false
-                    }
-                });
-            }
         }
 
         Self::with_detached_windows(|windows, parallel| {
@@ -1967,7 +1937,7 @@ impl ImageRenderWindowsService for WINDOWS {
         if let Some(args) = FRAME_IMAGE_READY_EVENT.on(update)
             && let Some(img) = &args.frame_image
         {
-            return Some((args.window_id, img.clone()));
+            return Some((args.window_id, img.get()));
         }
         None
     }

--- a/crates/zng-ext-window/src/types.rs
+++ b/crates/zng-ext-window/src/types.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "image")]
 use zng_app::window::WINDOW;
 #[cfg(feature = "image")]
-use zng_ext_image::{ImageSource, ImageVar, Img};
+use zng_ext_image::{ImageSource, ImageVar};
 #[cfg(feature = "image")]
 use zng_layout::unit::Point;
 #[cfg(feature = "image")]
@@ -588,7 +588,7 @@ event_args! {
         /// See [`WindowVars::frame_capture_mode`] for more details.
         ///
         /// [`WindowVars::frame_capture_mode`]: crate::WindowVars::frame_capture_mode
-        pub frame_image: Option<Img>,
+        pub frame_image: Option<ImageVar>,
 
         ..
 

--- a/crates/zng-view-api/src/image.rs
+++ b/crates/zng-view-api/src/image.rs
@@ -556,10 +556,9 @@ impl std::cmp::PartialOrd for ImageEntryKind {
 
 /// Represents a partial or fully decoded image.
 ///
-/// See [`Event::ImageDecoded`] and [`ImagePartiallyDecoded`] for more details.
+/// See [`Event::ImageDecoded`] for more details.
 ///
 /// [`Event::ImageDecoded`]: crate::Event::ImageDecoded
-/// [`ImagePartiallyDecoded`]: crate::Event::ImagePartiallyDecoded
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct ImageDecoded {

--- a/crates/zng-view-api/src/image.rs
+++ b/crates/zng-view-api/src/image.rs
@@ -500,6 +500,18 @@ impl ImageMetadata {
         }
     }
 }
+impl Default for ImageMetadata {
+    fn default() -> Self {
+        Self {
+            id: ImageId::INVALID,
+            size: Default::default(),
+            density: Default::default(),
+            is_mask: Default::default(),
+            original_color_type: ColorType::BGRA8,
+            parent: Default::default(),
+        }
+    }
+}
 
 /// Kind of image container entry an image was decoded from.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -553,6 +565,14 @@ impl std::cmp::PartialOrd for ImageEntryKind {
 pub struct ImageDecoded {
     /// Image metadata.
     pub meta: ImageMetadata,
+
+    /// If the [`pixels`] only represent a partial image.
+    ///
+    /// When this is `None` the image has fully loaded.
+    ///
+    /// [`pixels`]: Self::pixels
+    pub partial: Option<PartialImageKind>,
+
     /// Decoded pixels.
     ///
     /// Is BGRA8 pre-multiplied if `!is_mask` or is `A8` if `is_mask`.
@@ -560,11 +580,50 @@ pub struct ImageDecoded {
     /// If all pixels have an alpha value of 255.
     pub is_opaque: bool,
 }
+impl Default for ImageDecoded {
+    fn default() -> Self {
+        Self {
+            meta: Default::default(),
+            partial: Default::default(),
+            pixels: Default::default(),
+            is_opaque: true,
+        }
+    }
+}
 impl ImageDecoded {
     /// New.
     pub fn new(meta: ImageMetadata, pixels: IpcBytes, is_opaque: bool) -> Self {
-        Self { meta, pixels, is_opaque }
+        Self {
+            meta,
+            partial: None,
+            pixels,
+            is_opaque,
+        }
     }
+}
+
+/// Represents what kind of partial data was decoded.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum PartialImageKind {
+    /// The [`pixels`] are a placeholder image that must fill the actual image size.
+    ///
+    /// [`pixels`]: ImageDecoded::pixels
+    Placeholder {
+        /// The placeholder size.
+        pixel_size: PxSize,
+    },
+    /// The [`pixels`] is an image with the image full width but with only `height`.
+    ///
+    /// [`pixels`]: ImageDecoded::pixels
+    Rows {
+        /// Offset of the decoded rows.
+        ///
+        /// This is 0 if the image decodes from top to bottom or is `actual_height - height` if it decodes bottom to top.
+        y: Px,
+        /// The actual height of the pixels.
+        height: Px,
+    },
 }
 
 bitflags! {

--- a/crates/zng-view-api/src/lib.rs
+++ b/crates/zng-view-api/src/lib.rs
@@ -508,16 +508,18 @@ declare_api! {
     ///
     /// If `mask` is set captures an A8 mask, otherwise captures a full BGRA8 image.
     ///
-    /// Returns immediately if an [`Event::FrameImageReady`] will be send when the image is ready.
-    /// Returns `0` if the window is not found.
+    /// Returns immediately, an [`Event::ImageDecoded`] will be send when the image is ready.
+    ///
+    /// Returns [`ImageId::INVALID`] if the window is not found.
     pub fn frame_image(&mut self, id: WindowId, mask: Option<ImageMaskMode>) -> ImageId;
 
     /// Create a new image from a selection of the current rendered frame.
     ///
     /// If `mask` is set captures an A8 mask, otherwise captures a full BGRA8 image.
     ///
-    /// Returns immediately if an [`Event::FrameImageReady`] will be send when the image is ready.
-    /// Returns `0` if the window is not found.
+    /// Returns immediately, an [`Event::ImageDecoded`] will be send when the image is ready.
+    ///
+    /// Returns [`ImageId::INVALID`] if the window is not found.
     pub fn frame_image_rect(&mut self, id: WindowId, rect: PxRect, mask: Option<ImageMaskMode>) -> ImageId;
 
     /// Set the video mode used when the window is in exclusive fullscreen.

--- a/crates/zng-view-api/src/types.rs
+++ b/crates/zng-view-api/src/types.rs
@@ -14,14 +14,14 @@ use crate::{
     mouse::{ButtonState, MouseButton, MouseScrollDelta},
     raw_input::{InputDeviceCapability, InputDeviceEvent, InputDeviceId, InputDeviceInfo},
     touch::{TouchPhase, TouchUpdate},
-    window::{EventFrameRendered, FrameId, HeadlessOpenData, MonitorId, MonitorInfo, WindowChanged, WindowId, WindowOpenData},
+    window::{EventFrameRendered, HeadlessOpenData, MonitorId, MonitorInfo, WindowChanged, WindowId, WindowOpenData},
 };
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use zng_task::channel::{ChannelError, IpcBytes};
 use zng_txt::Txt;
-use zng_unit::{DipPoint, PxRect, Rgba};
+use zng_unit::{DipPoint, Rgba};
 
 macro_rules! declare_id {
     ($(
@@ -211,8 +211,6 @@ pub enum Event {
     },
 
     /// A frame finished rendering.
-    ///
-    /// `EventsCleared` is not send after this event.
     FrameRendered(EventFrameRendered),
 
     /// Window moved, resized, or minimized/maximized etc.
@@ -438,12 +436,8 @@ pub enum Event {
 
     /// An image resource already decoded header metadata.
     ImageMetadataDecoded(ImageMetadata),
-    /// An image resource finished decoding.
+    /// An image resource has partially or fully decoded.
     ImageDecoded(ImageDecoded),
-    /// An image resource, progressively decoded has decoded more rows.
-    ///
-    /// The data size and pixels reflects the partial height of the image that has decoded only.
-    ImagePartiallyDecoded(ImageDecoded),
     /// An image resource failed to decode, the image ID is not valid.
     ImageDecodeError {
         /// The image that failed to decode.
@@ -464,18 +458,6 @@ pub enum Event {
         task: ImageEncodeId,
         /// The error message.
         error: Txt,
-    },
-
-    /// An image generated from a rendered frame is ready.
-    FrameImageReady {
-        /// Window that had pixels copied.
-        window: WindowId,
-        /// The frame that was rendered when the pixels where copied.
-        frame: FrameId,
-        /// The frame image.
-        image: ImageId,
-        /// The pixel selection relative to the top-left.
-        selection: PxRect,
     },
 
     /* Config events */

--- a/crates/zng-view-api/src/window.rs
+++ b/crates/zng-view-api/src/window.rs
@@ -342,9 +342,9 @@ pub struct FrameRequest {
 
     /// Create an image or mask from this rendered frame.
     ///
-    /// The [`Event::FrameImageReady`] is sent with the image.
+    /// The [`Event::FrameRendered`] will have the frame image.
     ///
-    /// [`Event::FrameImageReady`]: crate::Event::FrameImageReady
+    /// [`Event::FrameRendered`]: crate::Event::FrameRendered
     pub capture: FrameCapture,
 
     /// Identifies this frame as the response to the [`WindowChanged`] resized frame request.
@@ -382,9 +382,9 @@ pub struct FrameUpdateRequest {
 
     /// Create an image or mask from this rendered frame.
     ///
-    /// The [`Event::FrameImageReady`] is send with the image.
+    /// The [`Event::FrameRendered`] will have the image.
     ///
-    /// [`Event::FrameImageReady`]: crate::Event::FrameImageReady
+    /// [`Event::FrameRendered`]: crate::Event::FrameRendered
     pub capture: FrameCapture,
 
     /// Identifies this frame as the response to the [`WindowChanged`] resized frame request.

--- a/crates/zng-view/src/image_cache/capture.rs
+++ b/crates/zng-view/src/image_cache/capture.rs
@@ -33,12 +33,6 @@ impl ImageCache {
                 image: id,
                 error: formatx!("no frame rendered in window `{window_id:?}`"),
             }));
-            let _ = self.app_sender.send(AppEvent::Notify(Event::FrameImageReady {
-                window: window_id,
-                frame: frame_id,
-                image: id,
-                selection: rect,
-            }));
             return id;
         }
 
@@ -47,12 +41,6 @@ impl ImageCache {
         let id = data.meta.id;
 
         let _ = self.app_sender.send(AppEvent::ImageDecoded(data));
-        let _ = self.app_sender.send(AppEvent::Notify(Event::FrameImageReady {
-            window: window_id,
-            frame: frame_id,
-            image: id,
-            selection: rect,
-        }));
 
         id
     }

--- a/crates/zng-view/src/image_cache/capture.rs
+++ b/crates/zng-view/src/image_cache/capture.rs
@@ -5,7 +5,7 @@ use zng_txt::formatx;
 use zng_unit::{Factor, PxDensity2d, PxDensityUnits as _, PxRect};
 use zng_view_api::{
     Event,
-    image::{ColorType, ImageDataFormat, ImageDecoded, ImageId, ImageMaskMode, ImageMetadata, ImageRequest},
+    image::{ColorType, ImageDecoded, ImageId, ImageMaskMode, ImageMetadata},
     window::{FrameId, WindowId},
 };
 
@@ -36,13 +36,21 @@ impl ImageCache {
             return id;
         }
 
-        let data = self.frame_image_data(gl, rect, scale_factor, mask);
-
-        let id = data.meta.id;
-
-        let _ = self.app_sender.send(AppEvent::ImageDecoded(data));
-
-        id
+        match self.frame_image_data(gl, rect, scale_factor, mask) {
+            Ok(data) => {
+                let id = data.meta.id;
+                let _ = self.app_sender.send(AppEvent::Notify(Event::ImageDecoded(data)));
+                id
+            }
+            Err(e) => {
+                let id = self.image_id_gen.lock().incr();
+                let _ = self.app_sender.send(AppEvent::Notify(Event::ImageDecodeError {
+                    image: id,
+                    error: formatx!("cannot create frame image for window `{window_id:?}`, {e}"),
+                }));
+                id
+            }
+        }
     }
 
     /// Create frame_image for a capture request in the FrameRequest.
@@ -52,31 +60,7 @@ impl ImageCache {
         rect: PxRect,
         scale_factor: Factor,
         mask: Option<ImageMaskMode>,
-    ) -> ImageDecoded {
-        let data = self.frame_image_data_impl(gl, rect, scale_factor, mask);
-
-        self.images.insert(
-            data.meta.id,
-            Image(Arc::new(ImageData::RawData {
-                size: data.meta.size,
-                range: 0..data.pixels.len(),
-                pixels: data.pixels.clone(),
-                is_opaque: data.is_opaque,
-                density: data.meta.density,
-                stripes: Mutex::new(Box::new([])),
-            })),
-        );
-
-        data
-    }
-
-    fn frame_image_data_impl(
-        &mut self,
-        gl: &dyn gleam::gl::Gl,
-        rect: PxRect,
-        scale_factor: Factor,
-        mask: Option<ImageMaskMode>,
-    ) -> ImageDecoded {
+    ) -> std::io::Result<ImageDecoded> {
         let (format, og_color_type) = match gl.get_type() {
             gleam::gl::GlType::Gl => (gleam::gl::BGRA, ColorType::BGRA8),
             gleam::gl::GlType::Gles => (gleam::gl::RGBA, ColorType::RGBA8),
@@ -89,7 +73,7 @@ impl ImageCache {
             format,
             gleam::gl::UNSIGNED_BYTE,
         );
-        let mut buf = IpcBytes::new_mut_blocking(pixels_flipped.len()).unwrap();
+        let mut buf = IpcBytes::new_mut_blocking(pixels_flipped.len())?;
         assert_eq!(rect.size.width.0 as usize * rect.size.height.0 as usize * 4, buf.len());
         let stride = 4 * rect.size.width.0 as usize;
         for (px, buf) in pixels_flipped.chunks_exact(stride).rev().zip(buf.chunks_exact_mut(stride)) {
@@ -119,16 +103,22 @@ impl ImageCache {
             // frame size is not large enough to trigger a memmap that can fail;
             let (pixels, size, density, is_opaque, is_mask) = r.unwrap();
 
-            let id = self.add(ImageRequest::new(
-                ImageDataFormat::A8 { size },
-                pixels.clone(),
-                u64::MAX,
-                None,
-                Some(mask),
-            ));
+            let id = self.image_id_gen.lock().incr();
+            self.images.insert(
+                id,
+                Image(Arc::new(ImageData::RawData {
+                    size,
+                    range: 0..pixels.len(),
+                    pixels: pixels.clone(),
+                    is_opaque,
+                    density,
+                    stripes: Mutex::new(Box::new([])),
+                })),
+            );
+
             let mut meta = ImageMetadata::new(id, size, is_mask, og_color_type);
             meta.density = density;
-            ImageDecoded::new(meta, pixels, is_opaque)
+            Ok(ImageDecoded::new(meta, pixels, is_opaque))
         } else {
             if format == gleam::gl::RGBA {
                 for rgba in buf.chunks_exact_mut(4) {
@@ -138,26 +128,26 @@ impl ImageCache {
 
             let is_opaque = buf.chunks_exact(4).all(|bgra| bgra[3] == 255);
 
-            let data = buf.finish_blocking().unwrap(); // frame size is not large enough to trigger an memmap that can fail
+            let data = buf.finish_blocking()?;
             let density = 96.0 * scale_factor.0;
             let density = Some(PxDensity2d::splat(density.ppi()));
             let size = rect.size;
 
-            let id = self.add(ImageRequest::new(
-                ImageDataFormat::Bgra8 {
+            let id = self.image_id_gen.lock().incr();
+            self.images.insert(
+                id,
+                Image(Arc::new(ImageData::RawData {
                     size,
+                    range: 0..data.len(),
+                    pixels: data.clone(),
+                    is_opaque,
                     density,
-                    original_color_type: og_color_type.clone(),
-                },
-                data.clone(),
-                u64::MAX,
-                None,
-                mask,
-            ));
-
+                    stripes: Mutex::new(Box::new([])),
+                })),
+            );
             let mut meta = ImageMetadata::new(id, size, false, og_color_type);
             meta.density = density;
-            ImageDecoded::new(meta, data, is_opaque)
+            Ok(ImageDecoded::new(meta, data, is_opaque))
         }
     }
 }

--- a/crates/zng-view/src/surface.rs
+++ b/crates/zng-view/src/surface.rs
@@ -450,12 +450,14 @@ impl Surface {
                 _ => None,
             };
             if let Some(mask) = capture {
-                captured_data = Some(images.frame_image_data(
-                    &**self.context.gl(),
-                    PxRect::from_size(self.size.to_px(self.scale_factor)),
-                    self.scale_factor,
-                    mask,
-                ));
+                captured_data = images
+                    .frame_image_data(
+                        &**self.context.gl(),
+                        PxRect::from_size(self.size.to_px(self.scale_factor)),
+                        self.scale_factor,
+                        mask,
+                    )
+                    .ok();
             }
         }
         (frame_id, captured_data)

--- a/crates/zng-view/src/window.rs
+++ b/crates/zng-view/src/window.rs
@@ -1637,12 +1637,14 @@ impl Window {
             if ext_args.redraw || msg.composite_needed {
                 self.redraw();
             }
-            Some(images.frame_image_data(
-                &**self.context.gl(),
-                PxRect::from_size(self.window.inner_size().to_px()),
-                scale_factor,
-                mask,
-            ))
+            images
+                .frame_image_data(
+                    &**self.context.gl(),
+                    PxRect::from_size(self.window.inner_size().to_px()),
+                    scale_factor,
+                    mask,
+                )
+                .ok()
         } else {
             None
         };

--- a/crates/zng-wgt-image/src/border.rs
+++ b/crates/zng-wgt-image/src/border.rs
@@ -27,7 +27,7 @@ pub fn border_img(
     let source = source.into_var();
     let slices = slices.into_var();
 
-    let mut img = var(Img::dummy(None)).read_only();
+    let mut img = var(Img::new_empty(Txt::default())).read_only();
     let mut _img_sub = VarHandle::dummy();
     let mut slices_img_size = PxSize::zero();
     let mut slices_px = PxSideOffsets::zero();
@@ -68,7 +68,7 @@ pub fn border_img(
                 }
             }
             UiNodeOp::Deinit => {
-                img = var(Img::dummy(None)).read_only();
+                img = var(Img::new_empty(Txt::default())).read_only();
                 _img_sub = VarHandle::dummy();
             }
             UiNodeOp::Update { .. } => {
@@ -97,7 +97,7 @@ pub fn border_img(
                         img = if is_cached {
                             // must not cache, but is cached, detach from cache.
 
-                            let img = mem::replace(&mut img, var(Img::dummy(None)).read_only());
+                            let img = mem::replace(&mut img, var(Img::new_empty(Txt::default())).read_only());
                             IMAGES.detach(img)
                         } else {
                             // must cache, but image is not cached, get source again.

--- a/crates/zng-wgt-image/src/lib.rs
+++ b/crates/zng-wgt-image/src/lib.rs
@@ -56,7 +56,7 @@ fn on_build(wgt: &mut WidgetBuilding) {
     wgt.set_child(node);
 
     let source = wgt.capture_var::<ImageSource>(property_id!(source)).unwrap_or_else(|| {
-        let error = Img::dummy(Some(Txt::from_static("no source")));
+        let error = Img::new_empty(Txt::from_static("no source"));
         let error = ImageSource::Image(var(error).read_only());
         const_var(error)
     });

--- a/crates/zng-wgt-image/src/node.rs
+++ b/crates/zng-wgt-image/src/node.rs
@@ -18,7 +18,7 @@ context_var! {
     pub static CONTEXT_IMAGE_VAR: Img = no_context_image();
 }
 fn no_context_image() -> Img {
-    Img::dummy(Some(Txt::from_static("no image source in context")))
+    Img::new_empty(Txt::from_static("no image source in context"))
 }
 
 /// Requests an image from [`IMAGES`] and sets [`CONTEXT_IMAGE_VAR`].
@@ -33,9 +33,9 @@ fn no_context_image() -> Img {
 /// [`IMAGES`]: zng_ext_image::IMAGES
 pub fn image_source(child: impl IntoUiNode, source: impl IntoVar<ImageSource>) -> UiNode {
     let source = source.into_var();
-    let ctx_img = var(Img::dummy(None));
+    let ctx_img = var(Img::new_empty(Txt::default()));
     let child = with_context_var(child, CONTEXT_IMAGE_VAR, ctx_img.read_only());
-    let mut img = var(Img::dummy(None)).read_only();
+    let mut img = var(Img::new_empty(Txt::default())).read_only();
     let mut _ctx_binding = None;
 
     match_node(child, move |child, op| match op {
@@ -96,7 +96,7 @@ pub fn image_source(child: impl IntoUiNode, source: impl IntoVar<ImageSource>) -
                     img = if is_cached {
                         // must not cache, but is cached, detach from cache.
 
-                        let img = mem::replace(&mut img, var(Img::dummy(None)).read_only());
+                        let img = mem::replace(&mut img, var(Img::new_empty(Txt::default())).read_only());
                         IMAGES.detach(img)
                     } else {
                         // must cache, but image is not cached, get source again.

--- a/crates/zng/src/app.rs
+++ b/crates/zng/src/app.rs
@@ -93,7 +93,7 @@
 //!             if let Some(img) = args.frame_image {
 //!                 // if the app runs with `run_headless(/* with_renderer: */ true)` an image is captured
 //!                 // and saved here.
-//!                 img.save("screenshot.png").await.unwrap();
+//!                 img.get().save("screenshot.png").await.unwrap();
 //!             }
 //!
 //!             // close the window, causing the app to exit.

--- a/examples/headless/src/headless.rs
+++ b/examples/headless/src/headless.rs
@@ -31,7 +31,7 @@ pub fn run() {
             // this event will fire every time a frame is rendered (just once in this case).
             on_frame_image_ready = async_hn_once!(|args: &FrameImageReadyArgs| {
                 // in this case a `frame_image` was already captured.
-                let img = args.frame_image.unwrap();
+                let img = args.frame_image.unwrap().get();
 
                 // we save it...
                 print!("saving ./screenshot.png ... ");

--- a/examples/headless/src/video.rs
+++ b/examples/headless/src/video.rs
@@ -38,7 +38,7 @@ pub fn run() {
 
             // this event will fire every time a frame is rendered.
             on_frame_image_ready = async_hn!(temp, frame, |args| {
-                let img = args.frame_image.unwrap();
+                let img = args.frame_image.unwrap().get();
 
                 let frame_i = frame.get();
                 frame.set(frame_i + 1);

--- a/examples/window/src/main.rs
+++ b/examples/window/src/main.rs
@@ -165,8 +165,9 @@ fn screenshot() -> UiNode {
                 tracing::info!("taking `screenshot.png`..");
 
                 let t = INSTANT.now();
-                let img = WINDOW.frame_image(None).get();
-                img.wait_done().await;
+                let img = WINDOW.frame_image(None);
+                img.wait_match(|i| i.is_loaded()).await;
+                let img = img.get();
                 tracing::info!("taken in {:?}, saving..", t.elapsed());
 
                 let t = INSTANT.now();
@@ -211,7 +212,7 @@ fn screenshot() -> UiNode {
                             frame_capture_mode = FrameCaptureMode::Next;
                             on_frame_image_ready = async_hn_once!(|args: &FrameImageReadyArgs| {
                                 tracing::info!("saving screenshot..");
-                                match args.frame_image.unwrap().save("screenshot.png").await {
+                                match args.frame_image.unwrap().get().save("screenshot.png").await {
                                     Ok(_) => tracing::info!("saved"),
                                     Err(e) => tracing::error!("{e}"),
                                 }

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -10,7 +10,7 @@ fn error_view_recursion() {
     let mut app = APP.defaults().run_headless(false);
     zng_app::test_log();
 
-    let img = var(Img::dummy(Some("test error".to_txt()))).read_only();
+    let img = var(Img::new_empty("test error".to_txt())).read_only();
 
     zng::image::IMAGES.load_in_headless().set(true);
     let ok = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
The previous wrapper around a shared data that is modified internally breaks variable propagation, and was more complicated.