### PR TITLE
Fix potential unsafe code in windows notification impl

### DIFF
--- a/crates/zng-view/src/notification/windows.rs
+++ b/crates/zng-view/src/notification/windows.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{pin::Pin, time::Duration};
 
 use win32_notif::{
     ManageNotification, NotifError, NotificationActivatedEventHandler, NotificationDataSet, NotificationDismissedEventHandler,
@@ -22,7 +22,7 @@ pub struct NotificationService {
     // SAFETY: not actually 'static, depends on `notifier` lifetime.
     notifications: Vec<(DialogId, Txt, win32_notif::Notification<'static>)>,
 
-    notifier: Option<win32_notif::ToastsNotifier>,
+    notifier: Option<Pin<Box<win32_notif::ToastsNotifier>>>,
     inited: bool,
     tag_gen: usize,
 }
@@ -64,7 +64,7 @@ impl NotificationService {
             win32_notif::ToastsNotifier::new(FALLBACK_ID)
         };
         self.notifier = match notifier {
-            Ok(n) => Some(n),
+            Ok(n) => Some(Box::pin(n)),
             Err(e) => {
                 tracing::error!("cannot init notifier service, {e}");
                 None


### PR DESCRIPTION
Code holds a reference to another field, we don't move the owning structs but there is no way to assert safety for this from the inside. Now uses a pin box to be actually safe.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->