### PR TITLE
Change `ByteLength` inner type to `u64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This release contains only advanced API breaking changes, it should not affect most use cases. The changes
 improve IPC performance and security.
 
+* **Breaking** Change `ByteLength` inner type to `u64`.
 * Add `IpcReadHandle` and related types.
     - **Breaking** View-process API now reads image and audio files directly.
 * **Breaking** Remove `IpcBytesMut` constructors from `IpcBytes`.

--- a/crates/zng-ext-audio/src/lib.rs
+++ b/crates/zng-ext-audio/src/lib.rs
@@ -470,7 +470,7 @@ fn audio(mut source: AudioSource, mut options: AudioOptions, limits: Option<Audi
                     ));
                 }
                 let file = std::fs::File::open(path)?;
-                if file.metadata()?.len() > limit.1.bytes() as u64 {
+                if file.metadata()?.len() > limit.1.bytes() {
                     return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "file length exceeds limit"));
                 }
                 IpcReadHandle::best_read_blocking(file)
@@ -567,7 +567,7 @@ fn audio_data(
         }
     };
     let data = data;
-    let mut request = AudioRequest::new(format.clone(), data_clone, limits.max_decoded_len.bytes() as u64);
+    let mut request = AudioRequest::new(format.clone(), data_clone, limits.max_decoded_len.bytes());
     request.tracks = options.tracks;
 
     let try_gen = VIEW_PROCESS.generation();

--- a/crates/zng-ext-font/src/lib.rs
+++ b/crates/zng-ext-font/src/lib.rs
@@ -2977,7 +2977,7 @@ impl fmt::Debug for FontBytes {
                 FontBytesImpl::System(_) => "Mmap",
             },
         );
-        b.field(".len", &self.len().bytes());
+        b.field(".len", &(self.len() as u64).bytes());
         if let FontBytesImpl::System(m) = &self.0 {
             b.field(".path", &m.path);
         }

--- a/crates/zng-ext-image/src/lib.rs
+++ b/crates/zng-ext-image/src/lib.rs
@@ -474,7 +474,7 @@ fn image(mut source: ImageSource, mut options: ImageOptions, limits: Option<Imag
                 }
                 let file = std::fs::File::open(path)?;
                 let len = file.metadata()?.len();
-                if len > limit.1.bytes() as u64 {
+                if len > limit.1.bytes() {
                     return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "file length exceeds limit"));
                 }
                 Ok((IpcReadHandle::best_read_blocking(file)?, len))
@@ -485,7 +485,7 @@ fn image(mut source: ImageSource, mut options: ImageOptions, limits: Option<Imag
             };
             zng_task::spawn_wait(move || match read(&path, (&limits.allow_path, limits.max_encoded_len)) {
                 Ok((data, len)) => {
-                    tracing::trace!("read {path:?}, len: {:?}, fmt: {data_format:?}", (len as usize).bytes());
+                    tracing::trace!("read {path:?}, len: {:?}, fmt: {data_format:?}", len.bytes());
                     image_data(false, Some(key), data_format, data, options, limits, r)
                 }
                 Err(e) => {
@@ -525,7 +525,7 @@ fn image(mut source: ImageSource, mut options: ImageOptions, limits: Option<Imag
             zng_task::spawn(async move {
                 match download(uri.clone(), accept, (limits.allow_uri.clone(), limits.max_encoded_len)).await {
                     Ok((fmt, data)) => {
-                        tracing::trace!("download {uri:?}, len: {:?}, fmt: {fmt:?}", data.len().bytes());
+                        tracing::trace!("download {uri:?}, len: {:?}, fmt: {fmt:?}", (data.len() as u64).bytes());
                         image_data(false, Some(key), fmt, data.into(), options, limits, r);
                     }
                     Err(e) => {
@@ -585,7 +585,7 @@ fn image_data(
     let mut request = ImageRequest::new(
         format.clone(),
         data_clone,
-        limits.max_decoded_len.bytes() as u64,
+        limits.max_decoded_len.bytes(),
         options.downscale.clone(),
         options.mask,
     );

--- a/crates/zng-ext-svg/src/lib.rs
+++ b/crates/zng-ext-svg/src/lib.rs
@@ -109,7 +109,7 @@ fn load_render(max_decoded_len: ByteLength, data: SvgData, downscale: Option<Ima
             }
 
             let render = |size: resvg::tiny_skia::IntSize| -> ImageSource {
-                if size.width() as usize * size.height() as usize * 4 > max_decoded_len.bytes() {
+                if size.width() as u64 * size.height() as u64 * 4 > max_decoded_len.bytes() {
                     return error(formatx!("cannot render svg, would exceed max {max_decoded_len} allowed"));
                 }
                 let mut data = match IpcBytesMut::new_blocking(size.width() as usize * size.height() as usize * 4) {
@@ -171,7 +171,7 @@ fn svg_data_from_unknown(data: &IpcReadHandle) -> Option<String> {
     data.seek(io::SeekFrom::Start(0)).ok()?;
 
     // 3KB should allow for some comments at beginning before <svg
-    let header_len = 3.kilobytes().bytes();
+    let header_len = 3.kilobytes().0 as usize;
 
     if buf == [0x1f, 0x8b] {
         // gzip magic number

--- a/crates/zng-layout/src/unit/length.rs
+++ b/crates/zng-layout/src/unit/length.rs
@@ -819,7 +819,7 @@ impl Length {
     ///
     /// This includes the sum of all nested [`Length::Expr`] heap memory.
     pub fn memory_used(&self) -> ByteLength {
-        std::mem::size_of::<Length>().bytes() + self.heap_memory_used()
+        (std::mem::size_of::<Length>() as u64).bytes() + self.heap_memory_used()
     }
 
     /// Sum total memory used in nested [`Length::Expr`] heap memory.

--- a/crates/zng-layout/src/unit/length/expr.rs
+++ b/crates/zng-layout/src/unit/length/expr.rs
@@ -39,7 +39,7 @@ impl LengthExpr {
     /// This includes the sum of all nested [`Length::Expr`] heap memory.
     pub fn memory_used(&self) -> ByteLength {
         use LengthExpr::*;
-        std::mem::size_of::<LengthExpr>().bytes()
+        (std::mem::size_of::<LengthExpr>() as u64).bytes()
             + match self {
                 Add(a, b) | Sub(a, b) | Max(a, b) | Min(a, b) | Lerp(a, b, _) => a.heap_memory_used() + b.heap_memory_used(),
                 Mul(a, _) | Div(a, _) | Abs(a) | Neg(a) | Unit(a) => a.heap_memory_used(),

--- a/crates/zng-task/src/channel/ipc_read.rs
+++ b/crates/zng-task/src/channel/ipc_read.rs
@@ -44,7 +44,7 @@ impl IpcReadHandle {
     /// Either keep the handle or read to bytes, whichever is likely to be faster for
     /// the common usage pattern of sending to another process and a single full read with some seeking.
     pub fn best_read_blocking(mut file: std::fs::File) -> io::Result<Self> {
-        if file.metadata()?.len() > 5.megabytes().bytes() as u64 {
+        if file.metadata()?.len() > 5.megabytes().0 {
             Ok(file.into())
         } else {
             file.seek(io::SeekFrom::Start(0))?;
@@ -55,7 +55,7 @@ impl IpcReadHandle {
     /// Either keep the handle or read to bytes, whichever is likely to be faster for
     /// the common usage pattern of sending to another process and a single full read with some seeking.
     pub async fn best_read(mut file: crate::fs::File) -> io::Result<Self> {
-        if file.metadata().await?.len() > 5.megabytes().bytes() as u64 {
+        if file.metadata().await?.len() > 5.megabytes().0 {
             let file = file.try_unwrap().await.unwrap();
             Ok(file.into())
         } else {

--- a/crates/zng-task/src/http.rs
+++ b/crates/zng-task/src/http.rs
@@ -524,14 +524,14 @@ impl Response {
     /// Get the body bytes length if it is downloaded or `Content-Length` value if it is present in the headers.
     pub fn content_len(&self) -> Option<ByteLength> {
         match &self.body {
-            ResponseBody::Done { bytes, .. } => Some(bytes.len().bytes()),
+            ResponseBody::Done { bytes, .. } => Some((bytes.len() as u64).bytes()),
             ResponseBody::Read { .. } => {
                 let len = self
                     .headers
                     .get(header::CONTENT_LENGTH)?
                     .to_str()
                     .ok()?
-                    .parse::<usize>()
+                    .parse::<u64>()
                     .ok()?
                     .bytes();
                 Some(len)

--- a/crates/zng-task/src/http/curl.rs
+++ b/crates/zng-task/src/http/curl.rs
@@ -214,19 +214,19 @@ fn read_metrics(metrics: Var<Metrics>, stderr: crate::process::ChildStderr) {
 fn parse_curl_bytes(s: &str) -> ByteLength {
     // https://everything.curl.dev/cmdline/progressmeter.html#units
     let (s, scale) = if let Some(s) = s.strip_suffix("K") {
-        (s, 2usize.pow(10))
+        (s, 2u64.pow(10))
     } else if let Some(s) = s.strip_suffix("M") {
-        (s, 2usize.pow(20))
+        (s, 2u64.pow(20))
     } else if let Some(s) = s.strip_prefix("G") {
-        (s, 2usize.pow(30))
+        (s, 2u64.pow(30))
     } else if let Some(s) = s.strip_prefix("T") {
-        (s, 2usize.pow(40))
+        (s, 2u64.pow(40))
     } else if let Some(s) = s.strip_prefix("P") {
-        (s, 2usize.pow(50))
+        (s, 2u64.pow(50))
     } else {
         (s, 1)
     };
-    let l: usize = s.parse().unwrap_or(0);
+    let l: u64 = s.parse().unwrap_or(0);
     ByteLength::from_byte(l * scale)
 }
 fn parse_curl_duration(s: &str) -> Duration {
@@ -264,7 +264,7 @@ fn run_response(
     if require_length {
         if let Some(l) = header.get(http::header::CONTENT_LENGTH)
             && let Ok(l) = l.to_str()
-            && let Ok(l) = l.parse::<usize>()
+            && let Ok(l) = l.parse::<u64>()
         {
             if l < max_length.bytes() {
                 return Err(Box::new(ContentLengthExceedsMaxError));

--- a/crates/zng-task/src/io.rs
+++ b/crates/zng-task/src/io.rs
@@ -50,7 +50,7 @@ impl MeasureInner {
         }
     }
 
-    fn on_read(&mut self, bytes: usize) {
+    fn on_read(&mut self, bytes: u64) {
         if bytes == 0 {
             return;
         }
@@ -72,7 +72,7 @@ impl MeasureInner {
         });
     }
 
-    fn on_write(&mut self, bytes: usize) {
+    fn on_write(&mut self, bytes: u64) {
         if bytes == 0 {
             return;
         }
@@ -134,7 +134,7 @@ impl<T> Measure<T> {
 
 fn bytes_per_sec(bytes: ByteLength, elapsed: Duration) -> ByteLength {
     let bytes_per_sec = bytes.0 as u128 / elapsed.as_nanos() / Duration::from_secs(1).as_nanos();
-    ByteLength(bytes_per_sec as usize)
+    ByteLength(bytes_per_sec as u64)
 }
 
 impl<T: AsyncRead> AsyncRead for Measure<T> {
@@ -145,7 +145,7 @@ impl<T: AsyncRead> AsyncRead for Measure<T> {
         // SAFETY: we don't move task
         match unsafe { Pin::new_unchecked(&mut self_.task) }.poll_read(cx, buf) {
             Poll::Ready(Ok(bytes)) => {
-                self_.inner.on_read(bytes);
+                self_.inner.on_read(bytes as u64);
                 Poll::Ready(Ok(bytes))
             }
             p => p,
@@ -160,7 +160,7 @@ impl<T: AsyncWrite> AsyncWrite for Measure<T> {
         // SAFETY: we don't move task
         match unsafe { Pin::new_unchecked(&mut self_.task) }.poll_write(cx, buf) {
             Poll::Ready(Ok(bytes)) => {
-                self_.inner.on_write(bytes);
+                self_.inner.on_write(bytes as u64);
                 Poll::Ready(Ok(bytes))
             }
             p => p,
@@ -197,14 +197,14 @@ impl<T: AsyncBufRead> AsyncBufRead for Measure<T> {
         let self_ = unsafe { self.get_unchecked_mut() };
         // SAFETY: we don't move task
         unsafe { Pin::new_unchecked(&mut self_.task) }.consume(amt);
-        self_.inner.on_read(amt);
+        self_.inner.on_read(amt as u64);
     }
 }
 impl<T: Read> Read for Measure<T> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         match self.task.read(buf) {
             Ok(bytes) => {
-                self.inner.on_read(bytes);
+                self.inner.on_read(bytes as u64);
                 Ok(bytes)
             }
             r => r,
@@ -215,7 +215,7 @@ impl<T: Write> Write for Measure<T> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         match self.task.write(buf) {
             Ok(bytes) => {
-                self.inner.on_write(bytes);
+                self.inner.on_write(bytes as u64);
                 Ok(bytes)
             }
             r => r,
@@ -233,7 +233,7 @@ impl<T: BufRead> BufRead for Measure<T> {
 
     fn consume(&mut self, amount: usize) {
         self.task.consume(amount);
-        self.inner.on_read(amount);
+        self.inner.on_read(amount as u64);
     }
 }
 
@@ -389,7 +389,7 @@ impl<S: AsyncRead> McBufReader<S> {
                 waker: McWaker::empty(),
                 lazy_wakers: vec![],
 
-                buf: Vec::with_capacity(10.kilobytes().0),
+                buf: Vec::with_capacity(10.kilobytes().0 as usize),
 
                 clones,
                 non_lazy_count: 1,
@@ -512,7 +512,7 @@ impl<S: AsyncRead> AsyncRead for McBufReader<S> {
 
                     let new_start = inner.buf.len();
 
-                    inner.buf.resize(inner.buf.len() + buf.len().max(10.kilobytes().0), 0);
+                    inner.buf.resize(inner.buf.len() + buf.len().max(10.kilobytes().0 as usize), 0);
 
                     let mut inner_cx = task::Context::from_waker(&waker);
 
@@ -647,7 +647,7 @@ impl<S> ReadLimited<S> {
     pub fn new(source: S, limit: ByteLength, on_limit: fn() -> std::io::Error) -> Self {
         Self {
             source,
-            limit: limit.0,
+            limit: limit.0.try_into().unwrap_or(usize::MAX),
             on_limit,
         }
     }
@@ -767,7 +767,7 @@ mod tests {
 
     #[test]
     pub fn mc_buf_reader_parallel() {
-        let data = Data::new(60.kilobytes().0);
+        let data = Data::new(60.kilobytes().0 as _);
 
         let mut expected = vec![0; data.len];
         let _ = data.clone().blocking_read(&mut expected[..]);
@@ -803,7 +803,7 @@ mod tests {
 
     #[test]
     pub fn mc_buf_reader_single() {
-        let data = Data::new(60.kilobytes().0);
+        let data = Data::new(60.kilobytes().0 as _);
 
         let mut expected = vec![0; data.len];
         let _ = data.clone().blocking_read(&mut expected[..]);
@@ -825,7 +825,7 @@ mod tests {
 
     #[test]
     pub fn mc_buf_reader_sequential() {
-        let data = Data::new(60.kilobytes().0);
+        let data = Data::new(60.kilobytes().0 as _);
 
         let mut expected = vec![0; data.len];
         let _ = data.clone().blocking_read(&mut expected[..]);
@@ -854,7 +854,7 @@ mod tests {
 
     #[test]
     pub fn mc_buf_reader_completed() {
-        let data = Data::new(60.kilobytes().0);
+        let data = Data::new(60.kilobytes().0 as _);
         let mut buf = Vec::with_capacity(data.len);
         let mut a = McBufReader::new(data);
 
@@ -873,7 +873,7 @@ mod tests {
 
     #[test]
     pub fn mc_buf_reader_error() {
-        let mut data = Data::new(20.kilobytes().0);
+        let mut data = Data::new(20.kilobytes().0 as _);
         data.set_error();
 
         let mut expected = vec![0; data.len];
@@ -901,7 +901,7 @@ mod tests {
 
     #[test]
     pub fn mc_buf_reader_error_completed() {
-        let mut data = Data::new(20.kilobytes().0);
+        let mut data = Data::new(20.kilobytes().0 as _);
         data.set_error();
 
         let mut buf = Vec::with_capacity(data.len);
@@ -924,7 +924,7 @@ mod tests {
 
     #[test]
     pub fn mc_buf_reader_parallel_with_delay1() {
-        let mut data = Data::new(60.kilobytes().0);
+        let mut data = Data::new(60.kilobytes().0 as _);
         data.enable_pending();
 
         let mut expected = vec![0; data.len];
@@ -961,7 +961,7 @@ mod tests {
 
     #[test]
     pub fn mc_buf_reader_parallel_with_delay2() {
-        let mut data = Data::new(60.kilobytes().0);
+        let mut data = Data::new(60.kilobytes().0 as _);
         data.enable_pending();
 
         let mut expected = vec![0; data.len];

--- a/crates/zng-task/src/progress.rs
+++ b/crates/zng-task/src/progress.rs
@@ -34,7 +34,7 @@ impl Progress {
     }
 
     /// New with completed `n` of `total`.
-    pub fn from_n_of(n: usize, total: usize) -> Self {
+    pub fn from_n_of(n: u64, total: u64) -> Self {
         Self::new(Self::normalize_n_of(n, total))
     }
 
@@ -72,7 +72,7 @@ impl Progress {
     /// Combine the factor completed [`fct`] with another factor computed from `n` of `total`.
     ///
     /// [`fct`]: Self::fct
-    pub fn and_n_of(self, n: usize, total: usize) -> Self {
+    pub fn and_n_of(self, n: u64, total: u64) -> Self {
         self.and_fct(Self::normalize_n_of(n, total))
     }
 
@@ -87,7 +87,7 @@ impl Progress {
     /// Replace the [`fct`] value with a new factor computed from `n` of `total`.
     ///
     /// [`fct`]: Self::fct
-    pub fn with_n_of(mut self, n: usize, total: usize) -> Self {
+    pub fn with_n_of(mut self, n: u64, total: u64) -> Self {
         self.factor = Self::normalize_n_of(n, total);
         self
     }
@@ -139,13 +139,13 @@ impl Progress {
         value
     }
 
-    fn normalize_n_of(n: usize, total: usize) -> Factor {
+    fn normalize_n_of(n: u64, total: u64) -> Factor {
         if n > total {
             -1.fct() // invalid, indeterminate
         } else if total == 0 {
             1.fct() // 0 of 0, complete
         } else {
-            Self::normalize_factor(Factor(n as f32 / total as f32))
+            Self::normalize_factor(Factor((n as f64 / total as f64) as f32))
         }
     }
 
@@ -212,7 +212,7 @@ impl_from_and_into_var! {
     fn from(status: Progress) -> f32 {
         status.fct().0
     }
-    fn from(n_total: (usize, usize)) -> Progress {
+    fn from(n_total: (u64, u64)) -> Progress {
         Progress::from_n_of(n_total.0, n_total.1)
     }
     fn from(indeterminate_message: Txt) -> Progress {

--- a/crates/zng-unit/src/byte.rs
+++ b/crates/zng-unit/src/byte.rs
@@ -44,7 +44,7 @@ pub trait ByteUnits {
     /// See [`ByteLength::from_tera`] for more details.
     fn terabytes(self) -> ByteLength;
 }
-impl ByteUnits for usize {
+impl ByteUnits for u64 {
     fn bytes(self) -> ByteLength {
         ByteLength(self)
     }
@@ -125,9 +125,9 @@ impl ByteUnits for f64 {
 /// you can use the [`ByteUnits`] extension methods to initialize from an integer literal.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
-pub struct ByteLength(pub usize); // TODO(breaking) use u64
-impl From<usize> for ByteLength {
-    fn from(value: usize) -> Self {
+pub struct ByteLength(pub u64);
+impl From<u64> for ByteLength {
+    fn from(value: u64) -> Self {
         Self(value)
     }
 }
@@ -159,7 +159,7 @@ impl ByteLength {
     /// Length in bytes.
     ///
     /// This is the same as `.0`.
-    pub fn bytes(&self) -> usize {
+    pub fn bytes(&self) -> u64 {
         self.0
     }
 
@@ -208,7 +208,7 @@ impl ByteLength {
     }
 
     /// Maximum representable byte length.
-    pub const MAX: ByteLength = ByteLength(usize::MAX);
+    pub const MAX: ByteLength = ByteLength(u64::MAX);
 
     /// Adds the two lengths without overflowing or wrapping.
     pub const fn saturating_add(self, rhs: ByteLength) -> ByteLength {
@@ -277,7 +277,7 @@ impl ByteLength {
     /// From bytes.
     ///
     /// This is the same as `ByteLength(bytes)`.
-    pub const fn from_byte(bytes: usize) -> Self {
+    pub const fn from_byte(bytes: u64) -> Self {
         ByteLength(bytes)
     }
 
@@ -288,7 +288,7 @@ impl ByteLength {
         ByteLength(bytes.round() as _)
     }
 
-    const fn new(value: usize, scale: usize) -> Self {
+    const fn new(value: u64, scale: u64) -> Self {
         ByteLength(value.saturating_mul(scale))
     }
 
@@ -299,7 +299,7 @@ impl ByteLength {
     /// From kibi-bytes.
     ///
     /// 1 kibi-byte equals 1024 bytes.
-    pub const fn from_kibi(kibi_bytes: usize) -> Self {
+    pub const fn from_kibi(kibi_bytes: u64) -> Self {
         Self::new(kibi_bytes, 1024)
     }
     /// From kibi-bytes.
@@ -312,7 +312,7 @@ impl ByteLength {
     /// From kilo-bytes.
     ///
     /// 1 kilo-byte equals 1000 bytes.
-    pub const fn from_kilo(kilo_bytes: usize) -> Self {
+    pub const fn from_kilo(kilo_bytes: u64) -> Self {
         Self::new(kilo_bytes, 1000)
     }
     /// From kilo-bytes.
@@ -325,8 +325,8 @@ impl ByteLength {
     /// From mebi-bytes.
     ///
     /// 1 mebi-byte equals 1024² bytes.
-    pub const fn from_mebi(mebi_bytes: usize) -> Self {
-        Self::new(mebi_bytes, 1024usize.pow(2))
+    pub const fn from_mebi(mebi_bytes: u64) -> Self {
+        Self::new(mebi_bytes, 1024u64.pow(2))
     }
     /// From mebi-bytes.
     ///
@@ -338,8 +338,8 @@ impl ByteLength {
     /// From mega-bytes.
     ///
     /// 1 mega-byte equals 1000² bytes.
-    pub const fn from_mega(mega_bytes: usize) -> Self {
-        Self::new(mega_bytes, 1000usize.pow(2))
+    pub const fn from_mega(mega_bytes: u64) -> Self {
+        Self::new(mega_bytes, 1000u64.pow(2))
     }
     /// From mega-bytes.
     ///
@@ -351,8 +351,8 @@ impl ByteLength {
     /// From gibi-bytes.
     ///
     /// 1 gibi-byte equals 1024³ bytes.
-    pub const fn from_gibi(gibi_bytes: usize) -> Self {
-        Self::new(gibi_bytes, 1024usize.pow(3))
+    pub const fn from_gibi(gibi_bytes: u64) -> Self {
+        Self::new(gibi_bytes, 1024u64.pow(3))
     }
     /// From gibi-bytes.
     ///
@@ -364,8 +364,8 @@ impl ByteLength {
     /// From giga-bytes.
     ///
     /// 1 giga-byte equals 1000³ bytes.
-    pub const fn from_giga(giga_bytes: usize) -> Self {
-        Self::new(giga_bytes, 1000usize.pow(3))
+    pub const fn from_giga(giga_bytes: u64) -> Self {
+        Self::new(giga_bytes, 1000u64.pow(3))
     }
     /// From giga-bytes.
     ///
@@ -377,8 +377,8 @@ impl ByteLength {
     /// From tebi-bytes.
     ///
     /// 1 tebi-byte equals 1024^4 bytes.
-    pub const fn from_tebi(tebi_bytes: usize) -> Self {
-        Self::new(tebi_bytes, 1024usize.pow(4))
+    pub const fn from_tebi(tebi_bytes: u64) -> Self {
+        Self::new(tebi_bytes, 1024u64.pow(4))
     }
     /// From tebi-bytes.
     ///
@@ -390,8 +390,8 @@ impl ByteLength {
     /// From tera-bytes.
     ///
     /// 1 tera-byte equals 1000^4 bytes.
-    pub const fn from_tera(tera_bytes: usize) -> Self {
-        Self::new(tera_bytes, 1000usize.pow(4))
+    pub const fn from_tera(tera_bytes: u64) -> Self {
+        Self::new(tera_bytes, 1000u64.pow(4))
     }
     /// From tera-bytes.
     ///
@@ -427,22 +427,22 @@ impl fmt::Debug for ByteLength {
 impl fmt::Display for ByteLength {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
-            if self.0 >= 1024usize.pow(4) {
+            if self.0 >= 1024u64.pow(4) {
                 write!(f, "{:.2}TiB", self.tebis())
-            } else if self.0 >= 1024usize.pow(3) {
+            } else if self.0 >= 1024u64.pow(3) {
                 write!(f, "{:.2}GiB", self.gibis())
-            } else if self.0 >= 1024usize.pow(2) {
+            } else if self.0 >= 1024u64.pow(2) {
                 write!(f, "{:.2}MiB", self.mebis())
             } else if self.0 >= 1024 {
                 write!(f, "{:.2}KiB", self.kibis())
             } else {
                 write!(f, "{}B", self.bytes())
             }
-        } else if self.0 >= 1000usize.pow(4) {
+        } else if self.0 >= 1000u64.pow(4) {
             write!(f, "{:.2}TB", self.teras())
-        } else if self.0 >= 1000usize.pow(3) {
+        } else if self.0 >= 1000u64.pow(3) {
             write!(f, "{:.2}GB", self.gigas())
-        } else if self.0 >= 1000usize.pow(2) {
+        } else if self.0 >= 1000u64.pow(2) {
             write!(f, "{:.2}MB", self.megas())
         } else if self.0 >= 1000 {
             write!(f, "{:.2}kB", self.kilos())
@@ -451,7 +451,7 @@ impl fmt::Display for ByteLength {
         }
     }
 }
-/// Parses `"##"`, `"##TiB"`, `"##GiB"`, `"##MiB"`, `"##KiB"`, `"##B"`, `"##TB"`, `"##GB"`, `"##MB"`, `"##kB"` and `"##B"` where `##` is an `usize`.
+/// Parses `"##"`, `"##TiB"`, `"##GiB"`, `"##MiB"`, `"##KiB"`, `"##B"`, `"##TB"`, `"##GB"`, `"##MB"`, `"##kB"` and `"##B"` where `##` is an `u64`.
 impl std::str::FromStr for ByteLength {
     type Err = std::num::ParseFloatError;
 
@@ -483,7 +483,7 @@ impl<S: Into<Factor>> ops::Mul<S> for ByteLength {
     type Output = Self;
 
     fn mul(mut self, rhs: S) -> Self {
-        self.0 = (self.0 as f64 * rhs.into().0 as f64) as usize;
+        self.0 = (self.0 as f64 * rhs.into().0 as f64) as u64;
         self
     }
 }
@@ -496,7 +496,7 @@ impl<S: Into<Factor>> ops::Div<S> for ByteLength {
     type Output = Self;
 
     fn div(mut self, rhs: S) -> Self {
-        self.0 = (self.0 as f64 / rhs.into().0 as f64) as usize;
+        self.0 = (self.0 as f64 / rhs.into().0 as f64) as u64;
         self
     }
 }

--- a/crates/zng-var/src/impls.rs
+++ b/crates/zng-var/src/impls.rs
@@ -213,7 +213,7 @@ impl_from_and_into_var! {
     fn from(d: DInstant) -> Deadline;
     fn from(d: Duration) -> Deadline;
 
-    fn from(b: usize) -> ByteLength;
+    fn from(b: u64) -> ByteLength;
 
     fn from(rad: AngleRadian) -> AngleTurn;
     fn from(grad: AngleGradian) -> AngleTurn;


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->