### PR TITLE
Fix widget scoped commands only matching ancestors when direct match is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix builds with inspector notifying INSPECT_CMD every frame.
 
 # 0.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix widget scoped commands only matching ancestors when direct match is disabled.
 * Fix builds with inspector notifying INSPECT_CMD every frame.
 
 # 0.22.0

--- a/crates/zng-app/src/event/command.rs
+++ b/crates/zng-app/src/event/command.rs
@@ -965,7 +965,7 @@ impl CommandArgs {
                     // if scope widget contains args scope widget
                     if let Some(t) = &self.target {
                         t.widgets_path().iter().position(|i| *i == scope_id).unwrap_or(usize::MAX)
-                            < t.widgets_path().iter().position(|i| *i == args_id).unwrap_or(usize::MAX)
+                            <= t.widgets_path().iter().position(|i| *i == args_id).unwrap_or(usize::MAX)
                     } else {
                         todo!()
                     }

--- a/crates/zng-ext-undo/src/lib.rs
+++ b/crates/zng-ext-undo/src/lib.rs
@@ -1234,8 +1234,8 @@ static_id! {
 
 /// Undo extension methods for commands.
 pub trait CommandUndoExt {
-    /// Gets the command scoped in the undo scope widget that is or contains the focused widget, or
-    /// scoped on the app if there is no focused undo scope.
+    /// Gets the command scoped to the undo scope widget that is (or contains) the focused widget.
+    /// If no undo scope is focused gets the command scoped on the app.
     fn undo_scoped(self) -> Var<Command>;
 
     /// Latest undo stack for the given scope, same as calling [`UNDO::undo_stack`] inside the scope.

--- a/crates/zng-wgt-inspector/src/live.rs
+++ b/crates/zng-wgt-inspector/src/live.rs
@@ -121,7 +121,8 @@ pub fn inspect_node(can_inspect: impl IntoVar<bool>) -> UiNode {
                 }
             });
         }
-        UiNodeOp::Render { .. } | UiNodeOp::RenderUpdate { .. } => {
+        UiNodeOp::Render { .. } | UiNodeOp::RenderUpdate { .. } if inspected_tree.is_some() && WINDOWS.vars(inspector).is_some() => {
+            // update render info
             INSPECT_CMD.scoped(WINDOW.id()).notify_param(InspectorUpdateOnly::Render);
         }
         _ => {}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -51,11 +51,11 @@ To update the fork crates:
 * We depend on `zng-webrender`, `zng-swgl` and all local dependencies of these crates. As of last publish these are:
 
 ```
+zng-webrender-build
 zng-peek-poke-derive
 zng-peek-poke
 zng-glsl-to-cxx
 zng-wr-malloc-size-of
-zng-webrender-build
 zng-swgl
 zng-webrender-api
 zng-wr-glyph-rasterizer


### PR DESCRIPTION
Also fix an INSPECTOR_CMD issue