### PR TITLE
Fix `print_tracing_filter` not filtering Webrender

### DIFF
--- a/crates/zng-app/src/lib.rs
+++ b/crates/zng-app/src/lib.rs
@@ -730,7 +730,8 @@ pub fn print_tracing_filter(level: &tracing::Level, metadata: &tracing::Metadata
 
     if metadata.level() == &tracing::Level::INFO && level < &tracing::Level::TRACE {
         // suppress large info about texture cache
-        if metadata.target().ends_with("webrender::device::gl") { // ends with to also support zng_webrender*
+        if metadata.target().ends_with("webrender::device::gl") {
+            // ends with to also support zng_webrender*
             return false;
         }
         // suppress config dump
@@ -743,7 +744,7 @@ pub fn print_tracing_filter(level: &tracing::Level, metadata: &tracing::Metadata
         if metadata.target().ends_with("webrender::device::gl") {
             // Suppress "Cropping texture upload Box2D((0, 0), (0, 1)) to None"
             // This happens when an empty frame is rendered.
-            if metadata.line() == Some(4647) {
+            if metadata.line() == Some(4652) {
                 return false;
             }
         }

--- a/crates/zng-app/src/lib.rs
+++ b/crates/zng-app/src/lib.rs
@@ -730,17 +730,17 @@ pub fn print_tracing_filter(level: &tracing::Level, metadata: &tracing::Metadata
 
     if metadata.level() == &tracing::Level::INFO && level < &tracing::Level::TRACE {
         // suppress large info about texture cache
-        if metadata.target() == "zng_webrender::device::gl" {
+        if metadata.target().ends_with("webrender::device::gl") { // ends with to also support zng_webrender*
             return false;
         }
         // suppress config dump
-        if metadata.target() == "zng_webrender::renderer::init" {
+        if metadata.target().ends_with("webrender::renderer::init") {
             return false;
         }
     } else if metadata.level() == &tracing::Level::WARN && level < &tracing::Level::DEBUG {
         // suppress webrender warnings:
         //
-        if metadata.target() == "zng_webrender::device::gl" {
+        if metadata.target().ends_with("webrender::device::gl") {
             // Suppress "Cropping texture upload Box2D((0, 0), (0, 1)) to None"
             // This happens when an empty frame is rendered.
             if metadata.line() == Some(4647) {


### PR DESCRIPTION
Now that we are back to depending on webrender, not zng_webrender the log target matching cannot be exact

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->