### PR TITLE
Fix `cursor` not applying when a child widget captures the pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `cursor` not applying when a child widget captures the pointer.
 * The `UpdateDeliveryList` type can now be cloned and extended.
 * Fix `rich_text` causing repeated updates.
 * Debug builds now detect incorrect repeated updates and logs an error.

--- a/crates/zng-ext-input/src/pointer_capture.rs
+++ b/crates/zng-ext-input/src/pointer_capture.rs
@@ -174,7 +174,9 @@ impl CaptureInfo {
             CaptureMode::Window => self.target.window_id() == wgt.0,
             CaptureMode::Widget => self.target.widget_id() == wgt.1,
             CaptureMode::Subtree => {
-                if let Some(wgt) = WINDOWS.widget_tree(wgt.0).and_then(|t| t.get(wgt.1)) {
+                if self.target.window_id() == wgt.0
+                    && let Some(wgt) = WINDOWS.widget_tree(wgt.0).and_then(|t| t.get(wgt.1))
+                {
                     for wgt in wgt.self_and_ancestors() {
                         if wgt.id() == self.target.widget_id() {
                             return true;

--- a/crates/zng-wgt-input/src/misc.rs
+++ b/crates/zng-wgt-input/src/misc.rs
@@ -26,6 +26,8 @@ static_id! {
 /// You can set this property to a [`CursorIcon`] for a named platform dependent icon, [`CursorImg`] for a custom image,
 /// or to `false` that converts to [`CursorSource::Hidden`].
 ///
+/// The cursor will apply to the widget an all descendants that don't set a cursor.
+///
 /// [`CursorImg`]: zng_ext_window::CursorImg
 #[property(CONTEXT, default(CursorIcon::Default))]
 pub fn cursor(child: impl IntoUiNode, cursor: impl IntoVar<CursorSource>) -> UiNode {
@@ -65,6 +67,7 @@ fn cursor_impl(id: WindowId) -> VarHandle {
     MOUSE_HOVERED_EVENT.hook(move |args| {
         if let Some(t) = &args.target
             && t.window_id() == id
+            && args.capture_allows((t.window_id(), t.widget_id()))
             && let Some(info) = WINDOWS.widget_tree(id).unwrap().get(t.widget_id())
         {
             let mut vars = None;
@@ -74,11 +77,6 @@ fn cursor_impl(id: WindowId) -> VarHandle {
                 };
             }
             for info in info.self_and_ancestors() {
-                if let Some(cap) = &args.capture
-                    && !cap.allows((id, info.id()))
-                {
-                    continue;
-                }
                 if let Some(cursor) = info.meta().get(*WIDGET_CURSOR_ID) {
                     let top = Some(info.id());
                     if current_top != top {

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -153,8 +153,9 @@ fn rich_text_focus_change_broadcast(child: impl IntoUiNode) -> UiNode {
                 args.prev_focus.iter().chain(args.new_focus.iter()).any(|p| p.contains(ctx.root_id))
             });
             if extend_propagation {
+                // visuals know to receive FOCUS_CHANGED_EVENT for rich root ID, so we just need to extend
+                // WidgetUpdates to reach all leaves
                 let mut extended_list = updates.delivery_list().clone();
-                // visuals know to receive FOCUS_CHANGED_EVENT for rich root ID too
                 for leaf in ctx.leaves() {
                     extended_list.insert_wgt(&leaf);
                 }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->