### PR TITLE
Add default context menu for `Markdown!` when `txt_selectable = true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Add default context menu for `Markdown!` when `txt_selectable = true`.
 * Add `Event::with_new` shorthand to avoid a `Event::var` clone in widget updates that do non standard event matching.
 * Pointer text selection implemented for rich text widgets.
     - Now works for mouse and touch events at any position in `rich_text = true; txt_selectable = true;` widgets area.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Add default context menu for `Markdown!` when `txt_selectable = true`.
+* Add default context menu for `Markdown!` and `AnsiText!` when `txt_selectable = true`.
 * Add `Event::with_new` shorthand to avoid a `Event::var` clone in widget updates that do non standard event matching.
 * Pointer text selection implemented for rich text widgets.
     - Now works for mouse and touch events at any position in `rich_text = true; txt_selectable = true;` widgets area.

--- a/crates/zng-wgt-ansi-text/Cargo.toml
+++ b/crates/zng-wgt-ansi-text/Cargo.toml
@@ -20,5 +20,8 @@ zng-wgt-scroll = { path = "../zng-wgt-scroll", version = "0.14.1", default-featu
 zng-wgt-stack = { path = "../zng-wgt-stack", version = "0.13.1", default-features = false }
 zng-ext-font = { path = "../zng-ext-font", version = "0.14.1", default-features = false }
 zng-wgt-input = { path = "../zng-wgt-input", version = "0.12.1", default-features = false }
+zng-wgt-menu = { path = "../zng-wgt-menu", version = "0.13.1", default-features = false }
+zng-wgt-button = { path = "../zng-wgt-button", version = "0.14.1", default-features = false }
+zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.12.1", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/crates/zng-wgt-ansi-text/src/lib.rs
+++ b/crates/zng-wgt-ansi-text/src/lib.rs
@@ -55,6 +55,7 @@ impl AnsiText {
 
             when #txt_selectable {
                 cursor = CursorIcon::Text;
+                zng_wgt_menu::context::context_menu_fn = WidgetFn::new(default_context_menu);
             }
         };
 
@@ -754,6 +755,19 @@ pub fn ansi_node(txt: impl IntoVar<Txt>) -> UiNode {
         }
         _ => {}
     })
+}
+
+/// Context menu set by the [`AnsiText!`] when [`txt_selectable`] is `true`.
+///
+/// [`AnsiText!`]: struct@AnsiText
+/// [`txt_selectable`]: fn@zng_wgt_text::txt_selectable
+pub fn default_context_menu(args: zng_wgt_menu::context::ContextMenuArgs) -> UiNode {
+    use zng_wgt_button::Button;
+    let id = args.anchor_id;
+    zng_wgt_menu::context::ContextMenu!(ui_vec![
+        Button!(zng_ext_clipboard::COPY_CMD.scoped(id)),
+        Button!(zng_wgt_text::cmd::SELECT_ALL_CMD.scoped(id)),
+    ])
 }
 
 static X_TERM_256: [(u8, u8, u8); 256] = [

--- a/crates/zng-wgt-markdown/Cargo.toml
+++ b/crates/zng-wgt-markdown/Cargo.toml
@@ -37,6 +37,7 @@ zng-ext-font = { path = "../zng-ext-font", version = "0.14.1", default-features 
 zng-ext-clipboard = { path = "../zng-ext-clipboard", version = "0.12.1", default-features = false }
 zng-ext-l10n = { path = "../zng-ext-l10n", version = "0.15.1", default-features = false }
 zng-app = { path = "../zng-app", version = "0.23.1", default-features = false }
+zng-wgt-menu = { path = "../zng-wgt-menu", version = "0.13.1", default-features = false }
 
 pulldown-cmark = { version = "0.13", default-features = false, features = ["html"] }
 http = { version = "1.1", default-features = false, features = ["std"] }

--- a/crates/zng-wgt-markdown/src/lib.rs
+++ b/crates/zng-wgt-markdown/src/lib.rs
@@ -61,6 +61,7 @@ impl Markdown {
 
             when #txt_selectable {
                 cursor = CursorIcon::Text;
+                zng_wgt_menu::context::context_menu_fn = WidgetFn::new(default_context_menu);
             }
         };
 
@@ -80,6 +81,19 @@ impl Markdown {
         /// Note that the copy is only in plain text, without any style.
         pub zng_wgt_text::txt_selectable(enabled: impl IntoVar<bool>);
     }
+}
+
+/// Context menu set by the [`Markdown!`] when [`txt_selectable`] is `true`.
+///
+/// [`Markdown!`]: struct@Markdown
+/// [`txt_selectable`]: fn@zng_wgt_text::txt_selectable
+pub fn default_context_menu(args: zng_wgt_menu::context::ContextMenuArgs) -> UiNode {
+    use zng_wgt_button::Button;
+    let id = args.anchor_id;
+    zng_wgt_menu::context::ContextMenu!(ui_vec![
+        Button!(zng_ext_clipboard::COPY_CMD.scoped(id)),
+        Button!(zng_wgt_text::cmd::SELECT_ALL_CMD.scoped(id)),
+    ])
 }
 
 /// Implements the markdown parsing and view generation, configured by contextual properties.


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->