### PR TITLE
Fix text selection not extending when pressed pointer is outside the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix text selection not extending when pressed pointer is outside the viewport.
 * Fix `SELECT_ALL_CMD` auto scrolling text to end.
     - Add `SCROLL.ignore_next_scroll_to_focused` for widgets that implement custom scrolling and also use auto scroll to focus.
 * Add default context menu for `Markdown!` and `AnsiText!` when `txt_selectable = true`.

--- a/crates/zng-wgt-text/src/node/layout.rs
+++ b/crates/zng-wgt-text/src/node/layout.rs
@@ -1459,7 +1459,6 @@ fn layout_text_edit_events(edit: &mut LayoutTextEdit) {
                 4 => {}
                 _ => unreachable!(),
             }
-            // !!: TODO handle rich captured events too?
         }
     });
     POINTER_CAPTURE_EVENT.each_update(false, |args| {

--- a/crates/zng-wgt-text/src/node/layout.rs
+++ b/crates/zng-wgt-text/src/node/layout.rs
@@ -1450,23 +1450,16 @@ fn layout_text_edit_events(edit: &mut LayoutTextEdit) {
     });
     MOUSE_MOVE_EVENT.each_update(false, |args| {
         if !edit.selection_move_handles.is_dummy() && selectable {
-            let handle = if let Some(rich_root_id) = TEXT.try_rich().map(|r| r.root_id) {
-                args.target.contains(rich_root_id)
-            } else {
-                args.target.widget_id() == widget.id()
-            };
+            args.propagation.stop();
 
-            if handle {
-                args.propagation.stop();
-
-                match edit.click_count {
-                    1 => TextSelectOp::select_nearest_to(args.position).call(),
-                    2 => TextSelectOp::select_word_nearest_to(false, args.position).call(),
-                    3 => TextSelectOp::select_line_nearest_to(false, args.position).call(),
-                    4 => {}
-                    _ => unreachable!(),
-                }
+            match edit.click_count {
+                1 => TextSelectOp::select_nearest_to(args.position).call(),
+                2 => TextSelectOp::select_word_nearest_to(false, args.position).call(),
+                3 => TextSelectOp::select_line_nearest_to(false, args.position).call(),
+                4 => {}
+                _ => unreachable!(),
             }
+            // !!: TODO handle rich captured events too?
         }
     });
     POINTER_CAPTURE_EVENT.each_update(false, |args| {


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->