### PR TITLE
Fix missing space in rich text copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix missing space in rich text copy when component texts are spaced by layout only.
 * Fix text wrap breaking word segment sequences.
 
 # 0.22.2

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -120,6 +120,12 @@ fn rich_text_cmds(child: impl IntoUiNode) -> UiNode {
                                     let line_info = leaf.rich_text_line_info();
                                     if line_info.starts_new_line && !line_info.is_wrap_start && !txt.is_empty() {
                                         txt.push('\n');
+                                    } else {
+                                        let spaced = matches!(t_frag.chars().next(), Some(c) if c.is_whitespace())
+                                            || matches!(txt.chars().last(), Some(c) if c.is_whitespace());
+                                        if !spaced {
+                                            txt.push(' ');
+                                        }
                                     }
 
                                     txt.push_str(&t_frag);


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->