### PR TITLE
Fix multiple fonts in the same word only rendering glyphs from one font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `WidgetBuilder::push_pre_build_action` helper for derived widgets affect build state before base widget build.
 * Add `zng::widget::bind_state_info` helper.
 
+* Fix multiple fonts in the same word only rendering glyphs from one font.
 * Fix `Var::set_from` contextual var.
 * Fix missing space in rich text copy when component texts are spaced by layout only.
 * Fix text wrap breaking word segment sequences.

--- a/crates/zng-ext-font/src/shaping.rs
+++ b/crates/zng-ext-font/src/shaping.rs
@@ -2707,6 +2707,7 @@ impl ShapedTextBuilder {
                 if matches!(info.kind, TextSegmentKind::Emoji) {
                     self.push_emoji_seg(shaped_seg, font);
                 }
+                self.push_font(font);
             });
         }
     }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->