### PR TITLE
Fix mnemonic activating when scopes inits already focused

### DIFF
--- a/crates/zng-wgt-input/src/gesture.rs
+++ b/crates/zng-wgt-input/src/gesture.rs
@@ -392,7 +392,7 @@ pub fn mnemonic_scope(child: impl IntoUiNode, is_scope: impl IntoVar<bool>) -> U
                     var_subs.push(
                         FOCUS_CHANGED_EVENT.subscribe_when(UpdateOp::Update, id, move |a| a.is_focus_enter(id) || a.is_focus_leave(id)),
                     );
-                    is_focus_within = FOCUS.focused().with(|f| matches!(f, Some(f) if f.contains(id)));
+                    is_focus_within = FOCUS.is_highlighting().get() && FOCUS.focused().with(|f| matches!(f, Some(f) if f.contains(id)));
                     set_shortcuts = is_focus_within;
 
                     // sub to each descendant mnemonic properties


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->