### PR TITLE
Fix localized command names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Fix `Var::cow` issues.
     - Now is contextualized when source is contextual.
     - Now does not force update on source value update.
+* Fix command metadata init sometimes not initing for the app scope.
+    - Fixes sporadic localized command names not translating.
 
 # 0.22.2
 

--- a/crates/zng-app/src/event/command.rs
+++ b/crates/zng-app/src/event/command.rs
@@ -200,7 +200,14 @@ macro_rules! __command {
                 let __l10n_arg = $l10n_arg;
                 $crate::event::paste! {$(
                     cmd.[<init_ $meta_ident>]($meta_init);
-                    $crate::event::init_meta_l10n(std::env!("CARGO_PKG_NAME"), std::env!("CARGO_PKG_VERSION"), &__l10n_arg, cmd, stringify!($meta_ident), &cmd.$meta_ident());
+                    $crate::event::init_meta_l10n(
+                        std::env!("CARGO_PKG_NAME"),
+                        std::env!("CARGO_PKG_VERSION"),
+                        &__l10n_arg,
+                        cmd,
+                        stringify!($meta_ident),
+                        &cmd.$meta_ident()
+                    );
                 )*}
             }
             $crate::event::app_local! {
@@ -435,7 +442,7 @@ impl Command {
                         write.meta_init = MetaInit::Initing(lock.clone());
                         let _init_guard = lock.1.lock();
                         drop(write);
-                        init(*self_);
+                        init(self_.scoped(CommandScope::App));
                         self_.local.write().meta_init = MetaInit::Inited;
                     }
                     MetaInit::Initing(l) => {


### PR DESCRIPTION
Command metadata init needs to happen using the App scope only, because initializers like l10n can read metadata.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->