### PR TITLE
Fix warning using embedded tar localization resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix warning using embedded tar localization resources.
 * Fix menu item label underlined in menus with scroll active.
 * Fix large submenu dropdown covering the header.
 

--- a/crates/zng-ext-l10n/src/sources/dir.rs
+++ b/crates/zng-ext-l10n/src/sources/dir.rs
@@ -97,7 +97,6 @@ impl L10nDir {
                             };
                             let file_str = utf8_path[4].rsplit_once('.').unwrap().0;
                             let file = Txt::from_str(if file_str == "_" { "" } else { file_str });
-
                             (lang, LangFilePath::new(pkg_name, pkg_version, file))
                         }
                         _ => {

--- a/crates/zng-ext-l10n/src/sources/tar.rs
+++ b/crates/zng-ext-l10n/src/sources/tar.rs
@@ -73,7 +73,8 @@ impl L10nTar {
                         // lang/file.ftl
                         2 => {
                             let lang = utf8_path[0];
-                            let file = Txt::from_str(utf8_path[1].rsplit_once('.').unwrap().0);
+                            let file_str = utf8_path[1].rsplit_once('.').unwrap().0;
+                            let file = Txt::from_str(if file_str == "_" { "" } else { file_str });
                             (lang, LangFilePath::current_app(file))
                         }
                         // lang/deps/pkg-name/pkg-version/file.ftl
@@ -90,7 +91,8 @@ impl L10nTar {
                                     continue;
                                 }
                             };
-                            let file = Txt::from_str(utf8_path[4]);
+                            let file_str = utf8_path[4].rsplit_once('.').unwrap().0;
+                            let file = Txt::from_str(if file_str == "_" { "" } else { file_str });
 
                             (lang, LangFilePath::new(pkg_name, pkg_version, file))
                         }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->