### PR TITLE
Add zng_view::no_gl_warmup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* On Windows, add `zng::view_process::default::no_gl_warmup`.
 
 # 0.22.4
 

--- a/crates/zng-view/src/gl.rs
+++ b/crates/zng-view/src/gl.rs
@@ -768,6 +768,25 @@ impl Drop for GlContext {
     }
 }
 
+/// Disable OpenGL driver warmup.
+///
+/// On Windows in some NVidia machines there is a slight delay on showing the first window that uses the GPU, to mitigate
+/// this the view-process spawns a driver *warmup* task to parallelize this cost. This warmup allocates some driver resources
+/// that last for the duration of the process, this function exists to avoid this allocation if the app will only use
+/// the software renderer.
+///
+/// This must be called before the view-process is started if running in same process mode, or before the
+/// view-process is spawned (APP start).
+///
+/// This sets the `"ZNG_VIEW_NO_GL_WARMUP"` env variable.
+#[cfg(all(windows, feature = "hardware"))]
+pub fn no_gl_warmup() {
+    // SAFETY: set_var is always safe on Windows, and we only read using env::var anyway
+    unsafe {
+        std::env::set_var("ZNG_VIEW_NO_GL_WARMUP", "true");
+    }
+}
+
 /// Warmup the OpenGL driver in a throwaway thread, some NVIDIA drivers have a slow startup (500ms~),
 /// hopefully this loads it in parallel while the app is starting up so we don't block creating the first window.
 #[cfg(all(windows, feature = "hardware"))]
@@ -775,13 +794,17 @@ pub(crate) fn warmup() {
     // idea copied from here:
     // https://hero.handmade.network/forums/code-discussion/t/2503-day_235_opengl%2527s_pixel_format_takes_a_long_time#13029
 
+    if std::env::var("ZNG_VIEW_NO_GL_WARMUP").is_ok() {
+        return;
+    }
+
     use windows_sys::Win32::Graphics::{
         Gdi::*,
         OpenGL::{self},
     };
 
     let _ = std::thread::Builder::new()
-        .name("warmup".to_owned())
+        .name("gl-warmup".to_owned())
         .stack_size(3 * 64 * 1024)
         .spawn(|| unsafe {
             let _span = tracing::trace_span!("open-gl-init").entered();

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -37,7 +37,7 @@
 //! # Software Backend
 //!
 //! The `webrender/swgl` software renderer can be used as fallback when no native OpenGL 3.2 driver is available, to build it
-//! the feature `"software"` must be enabled (it is by default) and on Windows MSVC the `clang-cl` dependency must be installed and
+//! the feature `"software"` must be enabled and on Windows MSVC the `clang-cl` dependency must be installed and
 //! associated with the `CC` and `CXX` environment variables, if requirements are not met a warning is emitted and the build fails.
 //!
 //! To install dependencies on Windows:
@@ -52,6 +52,16 @@
 //! setx CXX clang-cl
 //! ```
 //! Note that you may need to reopen the terminal for the environment variables to be available (setx always requires this).
+//!
+//! ## Software Only
+//!
+//! The software renderer is not as efficient as the GPU one, but it uses significantly less memory, this might be of
+//! advantage for very small single window apps. To support with only software build without the `"hardware"` feature,
+//! this will also generate a smaller binary.
+//!
+//! Note that in `"hardware"` builds for Windows the OpenGL driver is *warmup* on startup, meaning resources for hardware
+//! rendering are allocated even if no subsequent window opens in hardware mode. You can call the `no_gl_warmup` function
+//! before the view-process start or spawn.
 //!
 //! # Pre-built
 //!
@@ -188,6 +198,9 @@ zng_env::on_process_start!(|args| {
         }
     }
 });
+
+#[cfg(all(windows, feature = "hardware"))]
+pub use gl::no_gl_warmup;
 
 /// Runs the view-process server.
 ///

--- a/crates/zng/src/view_process.rs
+++ b/crates/zng/src/view_process.rs
@@ -43,6 +43,9 @@
 pub mod default {
     pub use zng_view::run_same_process;
 
+    #[cfg(all(windows, feature = "view_hardware"))]
+    pub use zng_view::no_gl_warmup;
+
     /// Android init types.
     ///
     /// See [`winit::platform::android`](https://docs.rs/winit/latest/winit/platform/android/) for more details


### PR DESCRIPTION
This enables apps that are build with `"view_hardware"` and `"view_software" ` but only use software after some init config to avoid allocating the GPU OpenGL driver.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->