### PR TITLE
Fix view_extensions_init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `WINDOW_EXTENSIONS.view_extensions_init` for an existing window after respawn.
 
 # 0.22.4
 

--- a/crates/zng-app/src/view_process.rs
+++ b/crates/zng-app/src/view_process.rs
@@ -1246,6 +1246,11 @@ type Result<T> = std::result::Result<T, ChannelError>;
 #[must_use = "the view is disposed when all clones of the handle are dropped"]
 pub struct ViewHeadless(ArcEq<ViewWindowData>);
 impl ViewHeadless {
+    /// Returns the view-process generation on which the headless surface was open.
+    pub fn generation(&self) -> ViewProcessGen {
+        self.0.generation
+    }
+
     /// Resize the headless surface.
     pub fn set_size(&self, size: DipSize, scale_factor: Factor) -> Result<()> {
         self.0.call(|id, p| p.set_headless_size(id, size, scale_factor))

--- a/crates/zng-env/src/lib.rs
+++ b/crates/zng-env/src/lib.rs
@@ -673,7 +673,7 @@ fn find_res() -> PathBuf {
 /// * The config dir can be set by [`init_config`] before any env dir is used.
 /// * In Android returns `android_internal("config")`.
 /// * In Linux, macOS and Windows if a file in `res("config-dir")` is found the first non-empty and non-comment (#) line
-///   defines the res path.
+///   defines the config path.
 /// * In `cfg(debug_assertions)` builds returns `target/tmp/dev_config/`.
 /// * In all platforms attempts [`directories::ProjectDirs::config_dir`] and panic if it fails.
 /// * If the config dir selected by the previous method contains a `"config-dir"` file it will be

--- a/crates/zng-ext-window/src/window.rs
+++ b/crates/zng-ext-window/src/window.rs
@@ -32,6 +32,7 @@ use zng_txt::Txt;
 use zng_unique_id::IdSet;
 use zng_var::{ResponderVar, ResponseVar, VarHandle};
 use zng_view_api::{
+    ViewProcessGen,
     api_extension::{ApiExtensionId, ApiExtensionPayload},
     config::{ColorsConfig, FontAntiAliasing},
     window::{FrameId, FrameRequest, FrameUpdateRequest, FrameWaitId, HeadlessRequest, WindowCapability, WindowRequest, WindowState},
@@ -129,8 +130,9 @@ pub(crate) struct WindowInstance {
     pub(crate) pending_loading: std::sync::Weak<dyn Any + Send + Sync>,
     pub(crate) vars: Option<WindowVars>,
     pub(crate) info: Option<WidgetInfoTree>,
-    pub(crate) extensions_init: Option<Vec<(ApiExtensionId, ApiExtensionPayload)>>,
+    pub(crate) extensions_init: Vec<(ApiExtensionId, ApiExtensionPayload)>,
     pub(crate) root: Option<WindowNode>,
+    pub(crate) view_generation: ViewProcessGen,
 }
 impl WindowInstance {
     pub(crate) fn new(
@@ -144,8 +146,9 @@ impl WindowInstance {
             pending_loading: std::sync::Weak::<()>::new(),
             vars: None,
             info: None,
-            extensions_init: Some(vec![]),
+            extensions_init: vec![],
             root: None,
+            view_generation: ViewProcessGen::INVALID,
         };
         UPDATES
             .run(async move {
@@ -600,6 +603,7 @@ pub(crate) fn layout_open_view((id, n, vars): &mut (WindowId, WindowNode, Option
                             let _ = window.focus();
                         }
 
+                        w.view_generation = window.generation();
                         r.renderer = Some(window.renderer());
                         r.view_window = Some(window);
                         r.view_opening = VarHandle::dummy();
@@ -785,6 +789,7 @@ pub(crate) fn layout_open_view((id, n, vars): &mut (WindowId, WindowNode, Option
 
                         let r = w.root.as_mut().unwrap();
                         let surface = a.surface.upgrade().unwrap();
+                        w.view_generation = surface.generation();
                         r.renderer = Some(surface.renderer());
                         r.view_headless = Some(surface);
                         r.view_opening = VarHandle::dummy();

--- a/crates/zng-ext-window/src/windows.rs
+++ b/crates/zng-ext-window/src/windows.rs
@@ -22,7 +22,7 @@ use zng_txt::{ToTxt as _, Txt, formatx};
 use zng_unique_id::{IdEntry, IdMap, IdSet};
 use zng_var::{ResponderVar, ResponseVar, VARS, Var, const_var, response_done_var, response_var, var, var_default};
 use zng_view_api::{
-    DragDropId,
+    DragDropId, ViewProcessGen,
     api_extension::{ApiExtensionId, ApiExtensionPayload},
     drag_drop::{DragDropData, DragDropEffect, DragDropError},
     window::{RenderMode, WindowCapability},
@@ -971,10 +971,10 @@ impl WINDOWS_EXTENSIONS {
     ) -> Result<(), ViewExtensionError> {
         match WINDOWS_SV.write().windows.get_mut(&window_id) {
             Some(w) => {
-                if matches!(w.mode, WindowMode::HeadlessWithRenderer) {
+                if matches!(w.mode, WindowMode::Headless) {
                     Err(ViewExtensionError::NotOpenInViewProcess(window_id))
-                } else if let Some(exts) = &mut w.extensions_init {
-                    exts.push((extension_id, request));
+                } else if w.view_generation == ViewProcessGen::INVALID || w.view_generation != VIEW_PROCESS.generation() {
+                    w.extensions_init.push((extension_id, request));
                     Ok(())
                 } else {
                     Err(ViewExtensionError::AlreadyOpenInViewProcess(window_id))
@@ -988,7 +988,7 @@ impl WINDOWS_EXTENSIONS {
             .write()
             .windows
             .get_mut(&window_id)
-            .and_then(|w| w.extensions_init.take())
+            .map(|w| mem::take(&mut w.extensions_init))
             .unwrap_or_default()
     }
 


### PR DESCRIPTION
On respawn the validation for the call was still detecting the window as open in the view-process