### PR TITLE
Implement compiled shader caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Implement compiled shader caching, enabled by default.
+    - Add `WINDOWS.default_cache_shaders` and `Window::cache_shaders`.
+
 * Fix view-process window extension calls from inside the same window.
 
 * Fix panic on trace recorder init when a tracing subscriber is already set.

--- a/crates/zng-ext-window/src/types.rs
+++ b/crates/zng-ext-window/src/types.rs
@@ -53,6 +53,7 @@ pub struct WindowRoot {
     pub(super) kiosk: bool,
     pub(super) transparent: bool,
     pub(super) render_mode: Option<RenderMode>,
+    pub(super) cache_shaders: Option<bool>,
     pub(super) headless_monitor: HeadlessMonitor,
     pub(super) start_focused: bool,
     pub(super) child: UiNode,
@@ -70,6 +71,7 @@ impl WindowRoot {
     /// * `start_focused` - If the window is forced to be the foreground keyboard focus after opening.
     /// * `root` - The root widget's outermost `CONTEXT` node, the window uses this and the `root_id` to form the root widget.
     #[expect(clippy::too_many_arguments)]
+    #[deprecated = "use new2 until next breaking release"]
     pub fn new(
         root_id: WidgetId,
         start_position: StartPosition,
@@ -86,6 +88,45 @@ impl WindowRoot {
             kiosk,
             transparent,
             render_mode,
+            cache_shaders: None,
+            headless_monitor,
+            start_focused,
+            child: root.into_node(),
+        }
+    }
+
+    /// New window from a `root` node that forms the window root widget.
+    ///
+    /// * `root_id` - Widget ID of `root`.
+    /// * `start_position` - Position of the window when it first opens.
+    /// * `kiosk` - Only allow fullscreen mode. Note this does not configure the windows manager, only blocks the app itself
+    ///   from accidentally exiting fullscreen. Also causes subsequent open windows to be child of this window.
+    /// * `transparent` - If the window should be created in a compositor mode that renders semi-transparent pixels as "see-through".
+    /// * `render_mode` - Render mode preference overwrite for this window, note that the actual render mode selected can be different.
+    /// * `cache_shaders` - Shader cache preference overwrite for this window.
+    /// * `headless_monitor` - "Monitor" configuration used in [headless mode](zng_app::window::WindowMode::is_headless).
+    /// * `start_focused` - If the window is forced to be the foreground keyboard focus after opening.
+    /// * `root` - The root widget's outermost `CONTEXT` node, the window uses this and the `root_id` to form the root widget.
+    // TODO(breaking) replace new
+    #[expect(clippy::too_many_arguments)]
+    pub fn new2(
+        root_id: WidgetId,
+        start_position: StartPosition,
+        kiosk: bool,
+        transparent: bool,
+        render_mode: Option<RenderMode>,
+        cache_shaders: Option<bool>,
+        headless_monitor: HeadlessMonitor,
+        start_focused: bool,
+        root: impl IntoUiNode,
+    ) -> Self {
+        WindowRoot {
+            id: root_id,
+            start_position,
+            kiosk,
+            transparent,
+            render_mode,
+            cache_shaders,
             headless_monitor,
             start_focused,
             child: root.into_node(),
@@ -101,6 +142,7 @@ impl WindowRoot {
     /// See [`new`] for other parameters.
     ///
     /// [`new`]: Self::new
+    #[deprecated = "use `new_container2` until next breaking release"]
     #[expect(clippy::too_many_arguments)]
     pub fn new_container(
         root_id: WidgetId,
@@ -112,12 +154,47 @@ impl WindowRoot {
         start_focused: bool,
         child: impl IntoUiNode,
     ) -> Self {
-        WindowRoot::new(
+        WindowRoot::new2(
             root_id,
             start_position,
             kiosk,
             transparent,
             render_mode,
+            None,
+            headless_monitor,
+            start_focused,
+            zng_app::widget::base::node::widget_inner(child),
+        )
+    }
+
+    /// New window from a `child` node that becomes the child of the window root widget.
+    ///
+    /// The `child` parameter is a node that is the window's content, if it is a full widget the `root_id` is the id of
+    /// an internal container widget that is the parent of `child`, if it is not a widget it will still be placed in the inner
+    /// nest group of the root widget.
+    ///
+    /// See [`new2`] for other parameters.
+    ///
+    /// [`new2`]: Self::new2
+    #[expect(clippy::too_many_arguments)]
+    pub fn new_container2(
+        root_id: WidgetId,
+        start_position: StartPosition,
+        kiosk: bool,
+        transparent: bool,
+        render_mode: Option<RenderMode>,
+        cache_shaders: Option<bool>,
+        headless_monitor: HeadlessMonitor,
+        start_focused: bool,
+        child: impl IntoUiNode,
+    ) -> Self {
+        WindowRoot::new2(
+            root_id,
+            start_position,
+            kiosk,
+            transparent,
+            render_mode,
+            cache_shaders,
             headless_monitor,
             start_focused,
             zng_app::widget::base::node::widget_inner(child),
@@ -127,11 +204,12 @@ impl WindowRoot {
     /// New test window.
     #[cfg(any(test, doc, feature = "test_util"))]
     pub fn new_test(child: impl IntoUiNode) -> Self {
-        WindowRoot::new_container(
+        WindowRoot::new_container2(
             WidgetId::named("test-window-root"),
             StartPosition::Default,
             false,
             false,
+            None,
             None,
             HeadlessMonitor::default(),
             false,

--- a/crates/zng-ext-window/src/window.rs
+++ b/crates/zng-ext-window/src/window.rs
@@ -715,7 +715,7 @@ pub(crate) fn layout_open_view(a: &mut WidgetUpdateArgs, updates: &Arc<LayoutUpd
                         }
                     });
                 }
-                let r = VIEW_PROCESS.open_window(WindowRequest::new(
+                let mut args = WindowRequest::new(
                     zng_view_api::window::WindowId::from_raw(id.get()),
                     vars.0.title.get(),
                     state_all,
@@ -754,7 +754,14 @@ pub(crate) fn layout_open_view(a: &mut WidgetUpdateArgs, updates: &Arc<LayoutUpd
                     vars.0.enabled_buttons.get(),
                     vars.0.system_shutdown_warn.get(),
                     WINDOWS_EXTENSIONS.take_view_extensions_init(id),
-                ));
+                );
+                args.cache_shaders = a
+                    .node
+                    .root
+                    .get_mut()
+                    .cache_shaders
+                    .unwrap_or_else(|| WINDOWS.default_cache_shaders().get());
+                let r = VIEW_PROCESS.open_window(args);
                 if r.is_err() {
                     tracing::error!("view-process window {id:?} open request failed, will retry on respawn");
                     a.node.view_opening = VarHandle::dummy();
@@ -809,7 +816,7 @@ pub(crate) fn layout_open_view(a: &mut WidgetUpdateArgs, updates: &Arc<LayoutUpd
                     false
                 });
 
-                let r = VIEW_PROCESS.open_headless(HeadlessRequest::new(
+                let mut args = HeadlessRequest::new(
                     zng_view_api::window::WindowId::from_raw(id.get()),
                     scale_factor,
                     size_dip,
@@ -819,7 +826,14 @@ pub(crate) fn layout_open_view(a: &mut WidgetUpdateArgs, updates: &Arc<LayoutUpd
                         .render_mode
                         .unwrap_or_else(|| WINDOWS.default_render_mode().get()),
                     WINDOWS_EXTENSIONS.take_view_extensions_init(id),
-                ));
+                );
+                args.cache_shaders = a
+                    .node
+                    .root
+                    .get_mut()
+                    .cache_shaders
+                    .unwrap_or_else(|| WINDOWS.default_cache_shaders().get());
+                let r = VIEW_PROCESS.open_headless(args);
                 if r.is_err() {
                     tracing::error!("view-process headless surface {id:?} open request failed, will retry on respawn");
                     a.node.view_opening = VarHandle::dummy();

--- a/crates/zng-ext-window/src/windows.rs
+++ b/crates/zng-ext-window/src/windows.rs
@@ -41,6 +41,7 @@ app_local! {
 pub(crate) struct WindowsService {
     exit_on_last_close: Var<bool>,
     pub(crate) default_render_mode: Var<RenderMode>,
+    pub(crate) default_cache_shaders: Var<bool>,
     parallel: Var<ParallelWin>,
     pub(crate) frame_duration_from_monitor: Var<bool>,
     // Mutex for Sync
@@ -62,6 +63,7 @@ impl WindowsService {
         let sv = Self {
             exit_on_last_close: var(true),
             default_render_mode: var_default(),
+            default_cache_shaders: var(true),
             parallel: var_default(),
             frame_duration_from_monitor: var(true),
             root_extenders: Mutex::new(vec![]),
@@ -166,6 +168,19 @@ impl WINDOWS {
     /// a different render mode if it cannot support the requested mode.
     pub fn default_render_mode(&self) -> Var<RenderMode> {
         WINDOWS_SV.read().default_render_mode.clone()
+    }
+
+    /// Defines if windows cache compiled shaders to disk.
+    ///
+    /// The cache can speed up the first rendered frame, but it does write artifacts to the cache dir, for each shader and driver used.
+    ///
+    /// This is enabled by default. This is recommended for all deployment to a single machine, portable deployments should consider
+    /// disabling it, specially if the cache dir is carried with the executable.
+    ///
+    /// Note that this setting only affects windows opened after it is changed, also the view-process may
+    /// not cache shaders depending on render mode and the graphics driver.
+    pub fn default_cache_shaders(&self) -> Var<bool> {
+        WINDOWS_SV.read().default_cache_shaders.clone()
     }
 
     /// Defines what window operations can run in parallel, between windows.
@@ -1289,12 +1304,13 @@ impl zng_ext_image::ImageRenderWindowsService for WINDOWS {
     }
 
     fn new_window_root(&self, node: UiNode, render_mode: RenderMode) -> Box<dyn zng_ext_image::ImageRenderWindowRoot> {
-        Box::new(WindowRoot::new_container(
+        Box::new(WindowRoot::new_container2(
             WidgetId::new_unique(),
             crate::StartPosition::Default,
             false,
             true,
             Some(render_mode),
+            None,
             crate::HeadlessMonitor::default(),
             false,
             node,

--- a/crates/zng-view-api/src/lib.rs
+++ b/crates/zng-view-api/src/lib.rs
@@ -274,6 +274,7 @@ declare_api! {
     ///
     /// Other methods may only be called after this event.
     fn init(&mut self, vp_gen: ViewProcessGen, is_respawn: bool, headless: bool);
+    // TODO(breaking) non_exhaustive init args
 
     /// Called once after exit, if running in a managed external process it will be killed after this call.
     fn exit(&mut self);

--- a/crates/zng-view-api/src/window.rs
+++ b/crates/zng-view-api/src/window.rs
@@ -117,6 +117,8 @@ pub struct HeadlessRequest {
 
     /// Render mode preference for this headless surface.
     pub render_mode: RenderMode,
+    /// Cache compiled shaders to disk.
+    pub cache_shaders: bool,
 
     /// Initial payload for API extensions.
     ///
@@ -138,6 +140,7 @@ impl HeadlessRequest {
             scale_factor,
             size,
             render_mode,
+            cache_shaders: true,
             extensions,
         }
     }
@@ -523,6 +526,8 @@ pub struct WindowRequest {
 
     /// Render mode preference for this window.
     pub render_mode: RenderMode,
+    /// Cache compiled shaders to disk.
+    pub cache_shaders: bool,
 
     /// Focus request indicator on init.
     pub focus_indicator: Option<FocusIndicator>,
@@ -591,6 +596,7 @@ impl WindowRequest {
             transparent,
             capture_mode,
             render_mode,
+            cache_shaders: true,
             focus_indicator,
             focus,
             extensions,

--- a/crates/zng-view/Cargo.toml
+++ b/crates/zng-view/Cargo.toml
@@ -154,8 +154,10 @@ zng-tp-licenses = { path = "../zng-tp-licenses", version = "0.9.0", default-feat
 zng-env = { path = "../zng-env", version = "0.11.1", default-features = false }
 zng-task = { path = "../zng-task", version = "0.13.1", default-features = false }
 
-webrender = { version = "0.68.1", default-features = false, features = ["static_freetype"], package = "zng-webrender" }
+# path = "../../../zng-webrender/webrender"
+webrender = { version = "0.68.2", default-features = false, features = ["static_freetype", "serialize_program"], package = "zng-webrender" }
 swgl = { version = "0.68.0", default-features = false, optional = true }
+postcard = { version = "1", default-features = false, features = ["alloc"] }
 
 linkme = { version = "0.3.35", default-features = false }
 

--- a/crates/zng-view/src/gl.rs
+++ b/crates/zng-view/src/gl.rs
@@ -768,32 +768,6 @@ impl Drop for GlContext {
     }
 }
 
-/// Warmup the OpenGL driver in a throwaway thread, some NVIDIA drivers have a slow startup (500ms~),
-/// hopefully this loads it in parallel while the app is starting up so we don't block creating the first window.
-#[cfg(all(windows, feature = "hardware"))]
-pub(crate) fn warmup() {
-    // idea copied from here:
-    // https://hero.handmade.network/forums/code-discussion/t/2503-day_235_opengl%2527s_pixel_format_takes_a_long_time#13029
-
-    use windows_sys::Win32::Graphics::{
-        Gdi::*,
-        OpenGL::{self},
-    };
-
-    let _ = std::thread::Builder::new()
-        .name("warmup".to_owned())
-        .stack_size(3 * 64 * 1024)
-        .spawn(|| unsafe {
-            let _span = tracing::trace_span!("open-gl-init").entered();
-            let hdc = GetDC(std::ptr::null_mut());
-            let _ = OpenGL::DescribePixelFormat(hdc, 0, 0, std::ptr::null_mut());
-            ReleaseDC(std::ptr::null_mut(), hdc);
-        });
-}
-
-#[cfg(not(all(windows, feature = "hardware")))]
-pub(crate) fn warmup() {}
-
 // check if equal or newer then 3.1
 #[cfg(feature = "hardware")]
 fn check_wr_gl_version(gl: &dyn gl::Gl) -> Result<(), String> {

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -1227,8 +1227,6 @@ impl App {
     pub fn run_headless(ipc: ipc::ViewChannels, ext: ViewExtensions) {
         tracing::info!("running headless view-process");
 
-        gl::warmup();
-
         let (app_sender, app_receiver) = channel::unbounded();
         let (request_sender, request_receiver) = channel::unbounded();
         let mut app = App::new(
@@ -1355,8 +1353,6 @@ impl App {
 
     pub fn run_headed(ipc: ipc::ViewChannels, ext: ViewExtensions) {
         tracing::info!("running headed view-process");
-
-        gl::warmup();
 
         let winit_span = tracing::trace_span!("winit::EventLoop::new").entered();
         #[cfg(not(target_os = "android"))]

--- a/crates/zng-view/src/surface.rs
+++ b/crates/zng-view/src/surface.rs
@@ -116,6 +116,10 @@ impl Surface {
             // optimize memory usage
             chunk_pool: Some(crate::util::wr_chunk_pool()),
 
+            use_optimized_shaders: true,
+            // optimize first frame time
+            cached_programs: Some(webrender::ProgramCache::new(Some(crate::util::wr_shader_cache(cfg.cache_shaders)))),
+
             //panic_on_gl_error: true,
             ..Default::default()
         };

--- a/crates/zng-view/src/surface.rs
+++ b/crates/zng-view/src/surface.rs
@@ -116,9 +116,12 @@ impl Surface {
             // optimize memory usage
             chunk_pool: Some(crate::util::wr_chunk_pool()),
 
-            use_optimized_shaders: true,
-            // optimize first frame time
-            cached_programs: Some(webrender::ProgramCache::new(Some(crate::util::wr_shader_cache(cfg.cache_shaders)))),
+            use_optimized_shaders: !context.is_software(),
+            cached_programs: if context.is_software() {
+                None
+            } else {
+                Some(webrender::ProgramCache::new(Some(crate::util::wr_shader_cache(cfg.cache_shaders))))
+            },
 
             //panic_on_gl_error: true,
             ..Default::default()

--- a/crates/zng-view/src/util.rs
+++ b/crates/zng-view/src/util.rs
@@ -1,7 +1,9 @@
 use std::any::Any;
 use std::backtrace::Backtrace;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::marker::PhantomData;
+use std::path::PathBuf;
 use std::sync::LazyLock;
 use std::{cell::Cell, sync::Arc};
 use std::{fmt, ops};
@@ -10,6 +12,7 @@ use rayon::ThreadPoolBuilder;
 use webrender::api as wr;
 use winit::event_loop::ActiveEventLoop;
 use winit::{event::ElementState, monitor::MonitorHandle};
+use zng_task::parking_lot::Mutex;
 use zng_txt::{ToTxt, Txt};
 use zng_unit::*;
 use zng_view_api::access::AccessNodeId;
@@ -1251,6 +1254,111 @@ pub(crate) fn wr_workers() -> Arc<rayon::ThreadPool> {
 pub(crate) fn wr_chunk_pool() -> Arc<webrender::ChunkPool> {
     static POOL: LazyLock<Arc<webrender::ChunkPool>> = LazyLock::new(|| Arc::new(webrender::ChunkPool::new()));
     POOL.clone()
+}
+
+pub(crate) fn wr_shader_cache(disk_cache: bool) -> Box<dyn webrender::ProgramCacheObserver> {
+    static CACHE: LazyLock<Arc<WrShaderCacheData>> = LazyLock::new(|| Arc::new(WrShaderCacheData::new()));
+    Box::new(WrShaderCache {
+        d: CACHE.clone(),
+        disk_cache,
+    })
+}
+struct WrShaderCacheData {
+    // disk cache
+    dir: PathBuf,
+    // memory cache, for better perf for multiple windows
+    mem: Mutex<HashMap<webrender::ProgramSourceDigest, Arc<webrender::ProgramBinary>>>,
+}
+impl WrShaderCacheData {
+    fn new() -> Self {
+        Self {
+            dir: zng_env::cache("zng-view-wr-shaders"),
+            mem: Mutex::default(),
+        }
+    }
+}
+// https://searchfox.org/firefox-main/source/gfx/webrender_bindings/src/program_cache.rs#100
+#[derive(Clone)]
+struct WrShaderCache {
+    d: Arc<WrShaderCacheData>,
+    disk_cache: bool,
+}
+impl webrender::ProgramCacheObserver for WrShaderCache {
+    fn save_shaders_to_disk(&self, entries: Vec<Arc<webrender::ProgramBinary>>) {
+        let mut mem = self.d.mem.lock();
+        for entry in &entries {
+            mem.insert(entry.source_digest().clone(), entry.clone());
+        }
+        if !self.disk_cache {
+            return;
+        }
+        let cache = self.d.clone();
+        zng_task::spawn_wait(move || {
+            for entry in entries {
+                let file = cache.dir.join(wr_shader_cache_file_name(entry.source_digest()));
+                let file = loop {
+                    match std::fs::File::create(&file) {
+                        Ok(f) => break f,
+                        Err(e) => {
+                            if !cache.dir.exists() && std::fs::create_dir_all(&cache.dir).is_ok() {
+                                continue;
+                            }
+                            tracing::error!("cannot save shader, {e}");
+                            return;
+                        }
+                    }
+                };
+                if let Err(e) = postcard::to_io(&entry, file) {
+                    tracing::error!("cannot save shader, {e}");
+                    return;
+                }
+            }
+        });
+    }
+
+    fn set_startup_shaders(&self, _: Vec<Arc<webrender::ProgramBinary>>) {
+        // Firefox saves a key list here to immediately load the memory cache on startup
+    }
+
+    fn try_load_shader_from_disk(&self, digest: &webrender::ProgramSourceDigest, c: &std::rc::Rc<webrender::ProgramCache>) {
+        let mut mem = self.d.mem.lock();
+
+        if let Some(p) = mem.get(digest) {
+            c.load_program_binary(p.clone());
+            return;
+        }
+
+        let file = self.d.dir.join(wr_shader_cache_file_name(digest));
+        match std::fs::read(file) {
+            Ok(b) => match postcard::from_bytes::<webrender::ProgramBinary>(&b) {
+                Ok(p) => {
+                    let p = Arc::new(p);
+                    mem.insert(digest.clone(), p.clone());
+                    c.load_program_binary(p);
+                }
+                Err(e) => {
+                    tracing::error!("cannot load shader, {e}");
+                }
+            },
+            Err(e) => {
+                if !matches!(e.kind(), std::io::ErrorKind::NotFound) {
+                    tracing::error!("cannot load shader, {e}");
+                }
+            }
+        }
+    }
+
+    fn notify_program_binary_failed(&self, program_binary: &Arc<webrender::ProgramBinary>) {
+        let mut mem = self.d.mem.lock();
+        mem.remove(program_binary.source_digest());
+        if self.disk_cache {
+            let file = self.d.dir.join(wr_shader_cache_file_name(program_binary.source_digest()));
+            let _ = std::fs::remove_file(file);
+        }
+    }
+}
+fn wr_shader_cache_file_name(digest: &webrender::ProgramSourceDigest) -> String {
+    format!("{digest}.v1.bin")
 }
 
 #[cfg(not(any(windows, target_os = "android")))]

--- a/crates/zng-view/src/window.rs
+++ b/crates/zng-view/src/window.rs
@@ -367,11 +367,10 @@ impl Window {
             // optimize memory usage
             chunk_pool: Some(crate::util::wr_chunk_pool()),
 
-            // rendering is broken on Android emulators with unoptimized shaders.
-            // see: https://github.com/servo/servo/pull/31727
-            // webrender issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1887337
-            #[cfg(target_os = "android")]
             use_optimized_shaders: true,
+            // optimize first frame time
+            cached_programs: Some(webrender::ProgramCache::new(Some(crate::util::wr_shader_cache(cfg.cache_shaders)))),
+            // precache_flags: webrender::ShaderPrecacheFlags::FULL_COMPILE,
 
             //panic_on_gl_error: true,
             ..Default::default()

--- a/crates/zng-view/src/window.rs
+++ b/crates/zng-view/src/window.rs
@@ -367,9 +367,12 @@ impl Window {
             // optimize memory usage
             chunk_pool: Some(crate::util::wr_chunk_pool()),
 
-            use_optimized_shaders: true,
-            // optimize first frame time
-            cached_programs: Some(webrender::ProgramCache::new(Some(crate::util::wr_shader_cache(cfg.cache_shaders)))),
+            use_optimized_shaders: !context.is_software(),
+            cached_programs: if context.is_software() {
+                None
+            } else {
+                Some(webrender::ProgramCache::new(Some(crate::util::wr_shader_cache(cfg.cache_shaders))))
+            },
             // precache_flags: webrender::ShaderPrecacheFlags::FULL_COMPILE,
 
             //panic_on_gl_error: true,

--- a/crates/zng-wgt-window/src/lib.rs
+++ b/crates/zng-wgt-window/src/lib.rs
@@ -89,12 +89,13 @@ impl Window {
     /// [`WindowRoot`]: zng_ext_window::WindowRoot
     pub fn widget_build(&mut self) -> WindowRoot {
         let mut wgt = self.widget_take();
-        WindowRoot::new(
+        WindowRoot::new2(
             wgt.capture_value_or_else(property_id!(Self::id), WidgetId::new_unique),
             wgt.capture_value_or_default::<StartPosition>(property_id!(Self::start_position)),
             wgt.capture_value_or_default(property_id!(Self::kiosk)),
             wgt.capture_value_or_else(property_id!(Self::allow_transparency), || true),
             wgt.capture_value_or_default::<Option<RenderMode>>(property_id!(Self::render_mode)),
+            wgt.capture_value_or_default::<Option<bool>>(property_id!(Self::cache_shaders)),
             wgt.capture_value_or_default::<HeadlessMonitor>(property_id!(Self::headless_monitor)),
             wgt.capture_value_or_default(property_id!(Self::start_focused)),
             wgt.build(),
@@ -207,7 +208,7 @@ pub fn allow_transparency(wgt: &mut WidgetBuilding, allow: impl IntoValue<bool>)
     wgt.expect_property_capture();
 }
 
-/// Render performance mode overwrite for this window, if set to `None` the [`WINDOWS.default_render_mode`] is used.
+/// Render mode overwrite for this window, if set to `None` the [`WINDOWS.default_render_mode`] is used.
 ///
 /// The `view-process` will try to match the mode, if it is not available a fallback mode is selected,
 /// see [`RenderMode`] for more details about each mode and fallbacks.
@@ -217,6 +218,15 @@ pub fn allow_transparency(wgt: &mut WidgetBuilding, allow: impl IntoValue<bool>)
 #[property(CONTEXT, widget_impl(Window))]
 pub fn render_mode(wgt: &mut WidgetBuilding, mode: impl IntoValue<Option<RenderMode>>) {
     let _ = mode;
+    wgt.expect_property_capture();
+}
+
+/// Compiled shader cache overwrite for this window, if set to `None` the [`WINDOWS.default_cache_shaders`] is used.
+///
+/// [`WINDOWS.default_cache_shaders`]: zng_ext_window::WINDOWS::default_cache_shaders
+#[property(CONTEXT, widget_impl(Window))]
+pub fn cache_shaders(wgt: &mut WidgetBuilding, enabled: impl IntoValue<Option<bool>>) {
+    let _ = enabled;
     wgt.expect_property_capture();
 }
 


### PR DESCRIPTION
Observed significant gains on window open with cached shaders.

This commit also removes the Windows OpenGL warmup, after analyzing many trace recording its clear that it is actually interfering with the first window open time, due to app-process faster start to window request.