### PR TITLE
Generate optimized shaders for Windows when using native OpenGL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Generate optimized shaders for Windows when using native OpenGL.
 * Fix markdown table alignment in right-to-left contexts.
 * Fix layout issues when using a `Wrap!` as a `Grid!` cell.
     - Fixes markdown default table layout.

--- a/crates/zng-app/src/lib.rs
+++ b/crates/zng-app/src/lib.rs
@@ -738,6 +738,10 @@ pub fn print_tracing_filter(level: &tracing::Level, metadata: &tracing::Metadata
         if metadata.target().ends_with("webrender::renderer::init") {
             return false;
         }
+        // Recycling stats: {}
+        if metadata.target().ends_with("webrender::render_backend") && metadata.line() == Some(888) {
+            return false;
+        }
     } else if metadata.level() == &tracing::Level::WARN && level < &tracing::Level::DEBUG {
         // suppress webrender warnings:
         //
@@ -745,6 +749,13 @@ pub fn print_tracing_filter(level: &tracing::Level, metadata: &tracing::Metadata
             // Suppress "Cropping texture upload Box2D((0, 0), (0, 1)) to None"
             // This happens when an empty frame is rendered.
             if metadata.line() == Some(4652) {
+                return false;
+            }
+            // Suppress Missing optimized shader source for {name}
+            // Webrender does not generate optimized alternates for every shader,
+            // for example "gpu_cache_update" is used by every app and is not optimized,
+            // when an optimized shader is not found the unoptimized fallback is used
+            if metadata.line() == Some(689) {
                 return false;
             }
         }

--- a/crates/zng-view/Cargo.toml
+++ b/crates/zng-view/Cargo.toml
@@ -155,7 +155,7 @@ zng-env = { path = "../zng-env", version = "0.11.2", default-features = false }
 zng-task = { path = "../zng-task", version = "0.13.2", default-features = false }
 
 # path = "../../../zng-webrender/webrender"
-webrender = { version = "0.68.2", default-features = false, features = ["static_freetype", "serialize_program"], package = "zng-webrender" }
+webrender = { version = "0.68.3", default-features = false, features = ["static_freetype", "serialize_program"], package = "zng-webrender" }
 swgl = { version = "0.68.0", default-features = false, optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std"] }
 


### PR DESCRIPTION
This is mostly a patch for Webrender, it was only generating optimized shaders for ANGLE on Windows