### PR TITLE
Optimize build size of `fast_image_resize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 # 0.22.6
 
-* Fix `start_position`issues.
+* Fix `start_position` issues.
     - Avoid opening with title bar out of monitor bounds.
     - Fix `CenterParent` when child window is larger.
 * Generate optimized shaders for Windows when using native OpenGL.

--- a/crates/zng-app/src/lib.rs
+++ b/crates/zng-app/src/lib.rs
@@ -758,6 +758,11 @@ pub fn print_tracing_filter(level: &tracing::Level, metadata: &tracing::Metadata
             if metadata.line() == Some(689) {
                 return false;
             }
+            // Suppress "Warnings detected on shader:"
+            // The shaders run fine on Firefox
+            if metadata.line() == Some(2143) {
+                return false;
+            }
         }
 
         // suppress font-kit warnings:

--- a/crates/zng-view/src/image_cache.rs
+++ b/crates/zng-view/src/image_cache.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "_image_any"), allow(unused))]
 
+use fast_image_resize::IntoImageView;
 use std::{
     fmt,
     io::{self, Seek as _, SeekFrom, Write as _},
@@ -893,12 +894,27 @@ impl ImageCache {
         resize_opt.mul_div_alpha = false;
         // default, best quality
         resize_opt.algorithm = fr::ResizeAlg::Convolution(fr::FilterType::Lanczos3);
-        // try to reuse cache
-        match resizer.try_lock() {
-            Some(mut r) => r.resize(&source_img, &mut dest_img, Some(&resize_opt)),
-            None => fr::Resizer::new().resize(&source_img, &mut dest_img, Some(&resize_opt)),
+
+        {
+            // try to reuse cache
+            let mut resizer = resizer.try_lock();
+            let mut new_resizer = None;
+            let resizer = match &mut resizer {
+                Some(r) => &mut **r,
+                None => new_resizer.get_or_insert_default(),
+            };
+
+            // use resize_typed directly so we only compile for U8 and U8x4
+            if entry.is_mask {
+                let source_img = source_img.image_view::<fr::pixels::U8>().unwrap();
+                let mut dest_img = dest_img.typed_image_mut().unwrap();
+                resizer.resize_typed(&source_img, &mut dest_img, Some(&resize_opt)).unwrap();
+            } else {
+                let source_img = source_img.image_view::<fr::pixels::U8x4>().unwrap();
+                let mut dest_img = dest_img.typed_image_mut().unwrap();
+                resizer.resize_typed(&source_img, &mut dest_img, Some(&resize_opt)).unwrap();
+            }
         }
-        .unwrap();
 
         let pixels = dest_buf.finish_blocking().ok()?;
 

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -589,6 +589,7 @@ mod __prelude {
         IntoValue, IntoVar, Var, VarValue, const_var, context_var, expr_var, flat_expr_var, merge_var, var, var_from, var_getter,
         var_state, when_var,
     };
+    // TODO(breaking) VarEq
 
     pub use crate::var::animation::easing;
 


### PR DESCRIPTION
This crate offers a dynamic `resize` function that instantiates a copy of `resize_typed` for each supported pixel format. We only use two formats, A8 and  BGRA8 so calling `resize_typed` directly should help the optimizer