### PR TITLE
Add `try_unwrap_vec` and `unwrap_or_to_vec` for `IpcBytes` and `IpcBytesMut`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Add `try_unwrap_vec` and `unwrap_or_to_vec` for `IpcBytes` and `IpcBytesMut`.
 
 # 0.22.6
 

--- a/crates/zng-task/src/channel/ipc_bytes.rs
+++ b/crates/zng-task/src/channel/ipc_bytes.rs
@@ -665,3 +665,27 @@ impl IntoIterator for IpcBytes {
         IpcBytesIntoIter::new(self)
     }
 }
+impl IpcBytes {
+    /// Unwrap to the heap bytes if the bytes are allocated on the heap and the [`IpcBytes`] reference is not shared in process.
+    pub fn try_unwrap_vec(self) -> Result<Vec<u8>, Self> {
+        if !matches!(&*self.0, IpcBytesData::Heap(_)) {
+            return Err(self);
+        }
+        match Arc::try_unwrap(self.0) {
+            Ok(b) => match b {
+                IpcBytesData::Heap(v) => Ok(v),
+                #[cfg(ipc)]
+                _ => unreachable!(),
+            },
+            Err(b) => Err(IpcBytes(b)),
+        }
+    }
+
+    /// Unwrap to the non shared heap bytes, or copy the bytes to a new heap allocation.
+    pub fn unwrap_or_to_vec(self) -> Vec<u8> {
+        match self.try_unwrap_vec() {
+            Ok(v) => v,
+            Err(e) => e.to_vec(),
+        }
+    }
+}

--- a/crates/zng-task/src/channel/ipc_bytes_mut.rs
+++ b/crates/zng-task/src/channel/ipc_bytes_mut.rs
@@ -807,3 +807,25 @@ impl IpcBytes {
         }
     }
 }
+
+impl IpcBytesMut {
+    /// Unwrap to the heap allocation, if the bytes are on the heap.
+    pub fn try_unwrap_to_vec(self) -> Result<Vec<u8>, Self> {
+        match self.inner {
+            IpcBytesMutInner::Heap(mut b) => {
+                b.truncate(self.len);
+                Ok(b)
+            }
+            #[cfg(ipc)]
+            inner => Err(Self { inner, ..self }),
+        }
+    }
+
+    /// Unwrap to the heap allocation, or copy to a new heap allocation.
+    pub fn unwrap_or_to_vec(self) -> Vec<u8> {
+        match self.try_unwrap_to_vec() {
+            Ok(b) => b,
+            Err(e) => e[..].to_vec(),
+        }
+    }
+}

--- a/crates/zng-view/src/image_cache.rs
+++ b/crates/zng-view/src/image_cache.rs
@@ -314,6 +314,10 @@ impl ImageCache {
         id
     }
 
+    pub fn resizer(&self) -> &Arc<ResizerCache> {
+        &self.resizer
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn add_impl(
         id_gen: Arc<Mutex<ImageId>>,

--- a/crates/zng-view/src/image_cache/encode.rs
+++ b/crates/zng-view/src/image_cache/encode.rs
@@ -4,7 +4,7 @@ use winit::{
 };
 use zng_task::channel::{IpcBytes, IpcBytesMut};
 use zng_txt::{ToTxt as _, formatx};
-use zng_unit::PxPoint;
+use zng_unit::{Px, PxPoint, PxSize};
 use zng_view_api::{
     Event,
     image::{ImageEncodeId, ImageEncodeRequest, ImageEntryKind, ImageFormatCapability, ImageId},
@@ -106,7 +106,7 @@ impl ImageCache {
 
 impl Image {
     /// Generate a window icon from the image.
-    pub fn icon(&self) -> Option<Icon> {
+    pub fn icon(&self, resizer_cache: &super::ResizerCache) -> Option<Icon> {
         let (size, pixels) = match &*self.0 {
             ImageData::RawData { size, pixels, .. } => (size, pixels),
             ImageData::NativeTexture { .. } => unreachable!(),
@@ -119,16 +119,10 @@ impl Image {
         } else {
             let r = if width > 255 || height > 255 {
                 // resize to max 255
-                let mut buf = pixels[..].to_vec();
-                bgra_pre_mul_to_rgba(&mut buf, self.is_opaque());
-                let img = image::ImageBuffer::from_raw(width, height, buf).unwrap();
-                let img = image::DynamicImage::ImageRgba8(img);
-                let img = img.resize(255, 255, image::imageops::FilterType::Lanczos3);
+                let mut buf = super::fast_resize(resizer_cache, self.0.is_mask(), *size, pixels, PxSize::splat(Px(255))).unwrap();
 
-                use image::GenericImageView;
-                let (width, height) = img.dimensions();
-                let buf = img.into_rgba8().into_raw();
-                winit::window::Icon::from_rgba(buf, width, height)
+                bgra_pre_mul_to_rgba(&mut buf, self.is_opaque());
+                winit::window::Icon::from_rgba(buf.unwrap_or_to_vec(), width, height)
             } else {
                 let mut buf = pixels[..].to_vec();
                 bgra_pre_mul_to_rgba(&mut buf, self.is_opaque());

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -2024,7 +2024,10 @@ impl Api for App {
             let id = config.id;
             let win = Window::open(
                 self.generation,
-                config.icon.and_then(|i| self.image_cache.get(i)).and_then(|i| i.icon()),
+                config
+                    .icon
+                    .and_then(|i| self.image_cache.get(i))
+                    .and_then(|i| i.icon(self.image_cache.resizer())),
                 config
                     .cursor_image
                     .and_then(|(i, h)| self.image_cache.get(i).and_then(|i| i.cursor(h, &self.winit_loop))),
@@ -2137,7 +2140,9 @@ impl Api for App {
     }
 
     fn set_icon(&mut self, id: WindowId, icon: Option<ImageId>) {
-        let icon = icon.and_then(|i| self.image_cache.get(i)).and_then(|i| i.icon());
+        let icon = icon
+            .and_then(|i| self.image_cache.get(i))
+            .and_then(|i| i.icon(self.image_cache.resizer()));
         self.with_window(id, |w| w.set_icon(icon), || ())
     }
 


### PR DESCRIPTION
Helper methods used in a binary size optimization, also included in the pull