### PR TITLE
Add `collect_cargo_about_for` and filter licenses from unused crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Optimize `collect_cargo_about` license collection.
     - Skips optional dependencies not being compiled.
     - Skips local crates (version `#.#.#-local`).
+* Add `collect_cargo_about_for` for workspaces where a local crate collects the licenses, but it is not the executable entry crate.
 
 * Add `.zr-l10n` tool for `cargo zng res`.
     - Auto filter dependencies for langs not translated in the local resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Optimize `collect_cargo_about` license collection.
+    - Skips optional dependencies not being compiled.
+    - Skips local crates (version `#.#.#-local`).
+
 * Add `.zr-l10n` tool for `cargo zng res`.
     - Auto filter dependencies for langs not translated in the local resources.
       Auto filter test langs. Strip comments.

--- a/crates/zng-tp-licenses/src/lib.rs
+++ b/crates/zng-tp-licenses/src/lib.rs
@@ -161,9 +161,18 @@ pub fn collect_cargo_about(about_cfg_path: &str) -> Vec<LicenseUsed> {
     cargo_about
         .arg("about")
         .arg("generate")
+        .arg("--manifest-path")
+        .arg("Cargo.toml") // build.rs current_dir is crate folder
         .arg("--format")
-        .arg("json")
-        .arg("--all-features");
+        .arg("json");
+
+    // only include licenses from actually used dependencies
+    if let Ok(features) = std::env::var("CARGO_CFG_FEATURE") {
+        for feature in features.split(',') {
+            cargo_about.arg("--features");
+            cargo_about.arg(feature);
+        }
+    }
 
     // cargo about returns an error on stdout redirect in PowerShell
     #[cfg(windows)]
@@ -190,7 +199,15 @@ pub fn collect_cargo_about(about_cfg_path: &str) -> Vec<LicenseUsed> {
     #[cfg(not(windows))]
     let json = String::from_utf8(output.stdout).unwrap();
 
-    parse_cargo_about(&json).expect("error parsing `cargo about` output")
+    let mut entries = parse_cargo_about(&json).expect("error parsing `cargo about` output");
+
+    // don't include local crates
+    entries.retain_mut(|e| {
+        e.used_by.retain(|u| !u.version.ends_with("-local"));
+        !e.used_by.is_empty()
+    });
+
+    entries
 }
 
 /// Parse the output of [`cargo about`].

--- a/crates/zng-tp-licenses/src/lib.rs
+++ b/crates/zng-tp-licenses/src/lib.rs
@@ -139,7 +139,7 @@ pub fn sort_licenses(l: &mut Vec<LicenseUsed>) {
     }
 }
 
-/// Calls [`cargo about`] for the crate.
+/// Calls [`cargo about`] for the building crate and features.
 ///
 /// This method must be used in build scripts (`build.rs`).
 ///
@@ -153,6 +153,36 @@ pub fn sort_licenses(l: &mut Vec<LicenseUsed>) {
 /// [`DOCS_RS`]: https://docs.rs/about/builds#detecting-docsrs
 #[cfg(feature = "build")]
 pub fn collect_cargo_about(about_cfg_path: &str) -> Vec<LicenseUsed> {
+    // TODO(breaking) &Path
+    // build.rs current_dir is crate folder
+    collect_cargo_about_for(
+        about_cfg_path,
+        "Cargo.toml",
+        &std::env::var("CARGO_CFG_FEATURE").unwrap_or_default(),
+    )
+}
+/// Calls [`cargo about`] for the given crate and features.
+///
+/// The `features` must be a comma separated list of cargo features.
+///
+/// Returns an empty vec if the [`DOCS_RS`] env var is set to any value or if `"ZNG_TP_LICENSES=false"` is set.
+///
+/// # Panics
+///
+/// Panics for any error, including `cargo about` errors and JSON deserialization errors.
+///
+/// [`cargo about`]: https://github.com/EmbarkStudios/cargo-about
+/// [`DOCS_RS`]: https://docs.rs/about/builds#detecting-docsrs
+#[cfg(feature = "build")]
+pub fn collect_cargo_about_for(
+    about_cfg_path: impl AsRef<std::path::Path>,
+    manifest_path: impl AsRef<std::path::Path>,
+    features: &str,
+) -> Vec<LicenseUsed> {
+    collect_cargo_about_for_impl(about_cfg_path.as_ref(), manifest_path.as_ref(), features)
+}
+#[cfg(feature = "build")]
+fn collect_cargo_about_for_impl(about_cfg_path: &std::path::Path, manifest_path: &std::path::Path, features: &str) -> Vec<LicenseUsed> {
     if std::env::var("DOCS_RS").is_ok() || std::env::var("ZNG_TP_LICENSES").unwrap_or_default() == "false" {
         return vec![];
     }
@@ -162,16 +192,15 @@ pub fn collect_cargo_about(about_cfg_path: &str) -> Vec<LicenseUsed> {
         .arg("about")
         .arg("generate")
         .arg("--manifest-path")
-        .arg("Cargo.toml") // build.rs current_dir is crate folder
+        .arg(manifest_path)
         .arg("--format")
-        .arg("json");
+        .arg("json")
+        .arg("--no-default-features");
 
     // only include licenses from actually used dependencies
-    if let Ok(features) = std::env::var("CARGO_CFG_FEATURE") {
-        for feature in features.split(',') {
-            cargo_about.arg("--features");
-            cargo_about.arg(feature);
-        }
+    for feature in features.split(',') {
+        cargo_about.arg("--features");
+        cargo_about.arg(feature);
     }
 
     // cargo about returns an error on stdout redirect in PowerShell
@@ -182,7 +211,7 @@ pub fn collect_cargo_about(about_cfg_path: &str) -> Vec<LicenseUsed> {
         cargo_about.arg("--output-file").arg(temp_file.path());
     }
 
-    if !about_cfg_path.is_empty() {
+    if !about_cfg_path.as_os_str().is_empty() {
         cargo_about.arg("--config").arg(about_cfg_path);
     }
 

--- a/crates/zng/Cargo.toml
+++ b/crates/zng/Cargo.toml
@@ -296,7 +296,8 @@ view_hardware = ["zng-view?/hardware"]
 #
 # Not enabled by default. Note that `"view_prebuilt"` always bundles licenses.
 view_bundle_licenses = ["zng-view?/bundle_licenses"]
-# TODO(breaking) this is called embedding, not bundling
+# TODO(breaking) this is called embedding, not bundling, 
+# also we don't need this here, if building with view licenses are already embedded
 
 # Enables IPC tasks, pre-build views and connecting to views running in another process.
 #


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->