### PR TITLE
Reduce `zng::task::parking_lot` reexports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* **Breaking** `zng::task::parking_lot` now only reexports primary types.
 * **Breaking** `Label!` no longer inherits `FocusableMix`.
 * Add `WINDOW_Ext as _` to `zng::prelude_wgt`.
 * Add `Label!` to `zng::prelude`.

--- a/crates/zng-app/Cargo.toml
+++ b/crates/zng-app/Cargo.toml
@@ -62,8 +62,7 @@ ipc = ["zng-view-api/ipc", "zng-task/ipc"]
 # Not enabled by default, but enabled by `feature="test_util"`.
 #
 # See `zng::app::spawn_deadlock_detection` for more details.
-deadlock_detection = ["zng-task/deadlock_detection"]
-
+deadlock_detection = ["parking_lot/deadlock_detection"]
 
 # Enable instrumented allocator and record allocations.
 #

--- a/crates/zng-app/src/crash_handler.rs
+++ b/crates/zng-app/src/crash_handler.rs
@@ -7,7 +7,6 @@
 //!
 //! See the `zng::app::crash_handler` documentation for more details.
 
-use parking_lot::Mutex;
 use std::{
     fmt,
     io::{BufRead, Write},
@@ -17,6 +16,7 @@ use std::{
 };
 use zng_clone_move::clmv;
 use zng_layout::unit::TimeUnits as _;
+use zng_task::parking_lot::Mutex;
 
 use zng_txt::{ToTxt as _, Txt};
 

--- a/crates/zng-app/src/event.rs
+++ b/crates/zng-app/src/event.rs
@@ -7,9 +7,9 @@ use crate::{
     update::UPDATES,
     widget::{AnyVarSubscribe, OnVarArgs},
 };
-use parking_lot::MappedRwLockReadGuard;
 use zng_app_context::AppLocal;
 use zng_task::channel;
+use zng_task::parking_lot::MappedRwLockReadGuard;
 use zng_var::{AnyVar, VARS, Var, VarHandle, VarUpdateId, VarValue};
 
 use crate::{

--- a/crates/zng-app/src/event/command.rs
+++ b/crates/zng-app/src/event/command.rs
@@ -167,8 +167,8 @@ macro_rules! command {
 #[doc(inline)]
 pub use command;
 
-use parking_lot::Mutex;
 use zng_state_map::{OwnedStateMap, StateId, StateMapMut, StateValue};
+use zng_task::parking_lot::Mutex;
 use zng_txt::Txt;
 use zng_unique_id::{static_id, unique_id_64};
 use zng_var::{Var, VarHandles, VarValue, const_var, impl_from_and_into_var, var};

--- a/crates/zng-app/src/handler.rs
+++ b/crates/zng-app/src/handler.rs
@@ -3,9 +3,9 @@
 use std::pin::Pin;
 use std::sync::Arc;
 
-use parking_lot::Mutex;
 #[doc(hidden)]
 pub use zng_clone_move::*;
+use zng_task::parking_lot::Mutex;
 use zng_txt::Txt;
 
 use crate::update::UPDATES;

--- a/crates/zng-app/src/lib.rs
+++ b/crates/zng-app/src/lib.rs
@@ -39,11 +39,11 @@ pub mod window;
 
 mod tests;
 
-use parking_lot::Mutex;
 use view_process::VIEW_PROCESS;
 use zng_clone_move::async_clmv;
 #[doc(hidden)]
 pub use zng_layout as layout;
+use zng_task::parking_lot::Mutex;
 use zng_txt::Txt;
 #[doc(hidden)]
 pub use zng_var as var;

--- a/crates/zng-app/src/running.rs
+++ b/crates/zng-app/src/running.rs
@@ -1256,7 +1256,6 @@ pub(crate) fn assert_not_view_process() {
 /// You can call it before `zng::env::init!` to detect deadlocks in other processes too.
 #[cfg(feature = "deadlock_detection")]
 pub fn spawn_deadlock_detection() {
-    use parking_lot::deadlock;
     use std::{
         sync::atomic::{self, AtomicBool},
         thread,
@@ -1276,7 +1275,7 @@ pub fn spawn_deadlock_detection() {
             loop {
                 thread::sleep(Duration::from_secs(10));
 
-                let deadlocks = deadlock::check_deadlock();
+                let deadlocks = parking_lot::deadlock::check_deadlock();
                 if deadlocks.is_empty() {
                     continue;
                 }

--- a/crates/zng-app/src/timer.rs
+++ b/crates/zng-app/src/timer.rs
@@ -8,7 +8,6 @@ use crate::{
     Deadline,
     handler::{Handler, HandlerExt as _},
 };
-use parking_lot::Mutex;
 use std::{
     fmt, mem,
     pin::Pin,
@@ -21,6 +20,7 @@ use std::{
 };
 use zng_app_context::app_local;
 use zng_handle::{Handle, HandleOwner, WeakHandle};
+use zng_task::parking_lot::Mutex;
 use zng_time::{DInstant, INSTANT, INSTANT_APP};
 use zng_var::{Var, WeakVar, var};
 

--- a/crates/zng-app/src/trace_recorder.rs
+++ b/crates/zng-app/src/trace_recorder.rs
@@ -16,9 +16,9 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use parking_lot::Mutex;
 use serde::Deserialize as _;
 use tracing_subscriber::{filter::EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
+use zng_task::parking_lot::Mutex;
 use zng_txt::{ToTxt as _, Txt};
 
 /// Represents a recorded trace.
@@ -631,6 +631,6 @@ zng_env::on_process_start!(|_| {
 zng_app_context::hot_static! {
     static RECORDING: Mutex<Option<tracing_chrome::FlushGuard>> = Mutex::new(None);
 }
-fn recording() -> parking_lot::MutexGuard<'static, Option<tracing_chrome::FlushGuard>> {
+fn recording() -> zng_task::parking_lot::MutexGuard<'static, Option<tracing_chrome::FlushGuard>> {
     zng_app_context::hot_static_ref!(RECORDING).lock()
 }

--- a/crates/zng-app/src/update.rs
+++ b/crates/zng-app/src/update.rs
@@ -8,10 +8,10 @@ use std::{
     task::Waker,
 };
 
-use parking_lot::Mutex;
 use zng_app_context::app_local;
 use zng_handle::{Handle, HandleOwner, WeakHandle};
 use zng_task::channel::ChannelError;
+use zng_task::parking_lot::Mutex;
 use zng_unique_id::IdSet;
 use zng_var::{VARS, VARS_APP, VarUpdateId};
 

--- a/crates/zng-app/src/view_process.rs
+++ b/crates/zng-app/src/view_process.rs
@@ -15,10 +15,10 @@ use crate::{
     window::{MonitorId, WindowId},
 };
 
-use parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard};
 use zng_app_context::app_local;
 use zng_layout::unit::{DipPoint, DipRect, DipSideOffsets, DipSize, Factor, Frequency, Px, PxPoint, PxRect};
 use zng_task::channel::{self, ChannelError, IpcBytes, IpcReadHandle, IpcReceiver, Receiver};
+use zng_task::parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard};
 use zng_txt::Txt;
 use zng_unique_id::IdMap;
 use zng_var::{ArcEq, ResponderVar, Var, VarHandle, WeakEq};

--- a/crates/zng-app/src/widget.rs
+++ b/crates/zng-app/src/widget.rs
@@ -11,7 +11,6 @@ mod easing;
 pub use easing::*;
 
 use atomic::Atomic;
-use parking_lot::{Mutex, RwLock};
 use std::{
     borrow::Cow,
     pin::Pin,
@@ -23,6 +22,7 @@ use zng_handle::Handle;
 use zng_layout::unit::{DipPoint, DipToPx as _, Layout1d, Layout2d, Px, PxPoint, PxTransform};
 use zng_state_map::{OwnedStateMap, StateId, StateMapMut, StateMapRef, StateValue};
 use zng_task::UiTask;
+use zng_task::parking_lot::{Mutex, RwLock};
 use zng_txt::{Txt, formatx};
 use zng_var::{AnyVar, BoxAnyVarValue, ResponseVar, VARS, Var, VarHandle, VarHandles, VarHookArgs, VarUpdateId, VarValue};
 use zng_view_api::display_list::ReuseRange;

--- a/crates/zng-app/src/widget/base.rs
+++ b/crates/zng-app/src/widget/base.rs
@@ -21,8 +21,8 @@ use crate::widget::{
     node::match_node,
     property,
 };
-use parking_lot::Mutex;
 use zng_layout::unit::FactorUnits as _;
+use zng_task::parking_lot::Mutex;
 use zng_var::{IntoValue, Var, animation::Transitionable, context_var, impl_from_and_into_var};
 
 /// Base widget.

--- a/crates/zng-app/src/widget/builder.rs
+++ b/crates/zng-app/src/widget/builder.rs
@@ -213,11 +213,11 @@ macro_rules! widget_type {
         $($widget)::+::widget_type()
     };
 }
-use parking_lot::Mutex;
 #[doc(inline)]
 pub use widget_type;
 use zng_app_context::context_local;
 use zng_app_proc_macros::widget;
+use zng_task::parking_lot::Mutex;
 use zng_txt::{Txt, formatx};
 use zng_unique_id::{IdEntry, IdMap, IdSet, unique_id_32};
 use zng_var::{

--- a/crates/zng-app/src/widget/info.rs
+++ b/crates/zng-app/src/widget/info.rs
@@ -5,8 +5,8 @@ use std::{borrow::Cow, fmt, mem, ops, sync::Arc, time::Duration};
 pub mod access;
 
 mod tree;
-use parking_lot::{MappedMutexGuard, Mutex, MutexGuard, RwLock};
 use tree::Tree;
+use zng_task::parking_lot::{MappedMutexGuard, Mutex, MutexGuard, RwLock};
 
 mod path;
 pub use path::*;

--- a/crates/zng-app/src/widget/info/access.rs
+++ b/crates/zng-app/src/widget/info/access.rs
@@ -2,10 +2,10 @@
 
 use std::num::NonZeroU32;
 
-use parking_lot::Mutex;
 use unic_langid::LanguageIdentifier;
 use zng_layout::unit::{Factor, PxSize, PxTransform};
 use zng_state_map::{StateId, static_id};
+use zng_task::parking_lot::Mutex;
 use zng_txt::Txt;
 use zng_unique_id::IdMap;
 use zng_var::{IntoVar, Var};

--- a/crates/zng-app/src/widget/info/builder.rs
+++ b/crates/zng-app/src/widget/info/builder.rs
@@ -1,9 +1,9 @@
-use parking_lot::Mutex;
 use zng_layout::{
     context::{InlineConstraints, InlineConstraintsLayout, InlineConstraintsMeasure, InlineSegment, InlineSegmentPos, LAYOUT, LayoutMask},
     unit::{Factor, Px, PxBox, PxPoint, PxRect, PxSize, PxVector},
 };
 use zng_state_map::{OwnedStateMap, StateId, StateMapMut, StateValue};
+use zng_task::parking_lot::Mutex;
 use zng_unique_id::IdMap;
 
 use crate::{

--- a/crates/zng-app/src/widget/inspector.rs
+++ b/crates/zng-app/src/widget/inspector.rs
@@ -44,8 +44,8 @@ mod inspector_only {
 #[cfg(feature = "inspector")]
 pub(crate) use inspector_only::*;
 
-use parking_lot::RwLock;
 use zng_state_map::StateId;
+use zng_task::parking_lot::RwLock;
 use zng_txt::Txt;
 use zng_unique_id::static_id;
 use zng_var::{AnyVar, Var, VarValue};

--- a/crates/zng-app/src/widget/node/adopt.rs
+++ b/crates/zng-app/src/widget/node/adopt.rs
@@ -1,4 +1,4 @@
-use parking_lot::Mutex;
+use zng_task::parking_lot::Mutex;
 
 use super::*;
 use std::{mem, sync::Arc};

--- a/crates/zng-app/src/widget/node/arc.rs
+++ b/crates/zng-app/src/widget/node/arc.rs
@@ -175,7 +175,7 @@ impl WeakNode {
     }
 }
 
-use parking_lot::Mutex;
+use zng_task::parking_lot::Mutex;
 
 use super::UiNode;
 

--- a/crates/zng-app/src/widget/node/extend.rs
+++ b/crates/zng-app/src/widget/node/extend.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parking_lot::Mutex;
+use zng_task::parking_lot::Mutex;
 
 use crate::widget::WidgetUpdateMode;
 

--- a/crates/zng-app/src/widget/node/list.rs
+++ b/crates/zng-app/src/widget/node/list.rs
@@ -17,11 +17,11 @@ use crate::{
         info::{WidgetInfo, WidgetInfoBuilder, WidgetLayout, WidgetMeasure},
     },
 };
-use parking_lot::Mutex;
 use task::ParallelIteratorExt;
 use zng_app_context::context_local;
 use zng_layout::unit::{Factor, PxSize, PxTransform, PxVector};
 use zng_state_map::StateId;
+use zng_task::parking_lot::Mutex;
 use zng_task::{self as task, rayon::prelude::*};
 use zng_unique_id::static_id;
 use zng_var::{animation::Transitionable, impl_from_and_into_var};

--- a/crates/zng-app/src/window.rs
+++ b/crates/zng-app/src/window.rs
@@ -9,9 +9,9 @@ use crate::{
         info::{WidgetInfo, WidgetInfoTree},
     },
 };
-use parking_lot::RwLock;
 use zng_app_context::context_local;
 use zng_state_map::{OwnedStateMap, StateId, StateMapMut, StateMapRef, StateValue};
+use zng_task::parking_lot::RwLock;
 use zng_txt::Txt;
 
 zng_unique_id::unique_id_32! {

--- a/crates/zng-ext-audio/Cargo.toml
+++ b/crates/zng-ext-audio/Cargo.toml
@@ -29,7 +29,6 @@ zng-env = { path = "../zng-env", version = "0.11.3", default-features = false }
 
 serde = { version = "1.0", default-features = false }
 once_cell = { version = "1.19", default-features = false, features = ["parking_lot"] }
-parking_lot = { version = "0.12", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 base64 = { version = "0.22", default-features = false, features = ["std"] }
 dunce = { version = "1.0", default-features = false }

--- a/crates/zng-ext-font/Cargo.toml
+++ b/crates/zng-ext-font/Cargo.toml
@@ -43,7 +43,6 @@ serde = { version = "1.0", default-features = false }
 unicase = { version = "2.7", default-features = false }
 rustybuzz = { version = "0.20", default-features = false, features = ["std"] }
 ttf-parser = { version = "0.25", default-features = false, features = ["std", "apple-layout", "opentype-layout", "variable-fonts"] }
-parking_lot = { version = "0.12", default-features = false }
 byteorder = { version = "1.5", default-features = false, features = ["std"] }
 icu_properties = { version = "2.0", default-features = false, features = ["compiled_data"] }
 bitflags = { version = "2.5", default-features = false, features = ["serde", "bytemuck"] }

--- a/crates/zng-ext-font/src/lib.rs
+++ b/crates/zng-ext-font/src/lib.rs
@@ -59,7 +59,6 @@ pub use self::hyphenation::*;
 mod unit;
 pub use unit::*;
 
-use parking_lot::{Mutex, RwLock};
 use pastey::paste;
 use zng_app::{
     event::{event, event_args},
@@ -76,6 +75,7 @@ use zng_layout::unit::{
     ByteUnits as _, EQ_GRANULARITY, EQ_GRANULARITY_100, Factor, FactorPercent, Px, PxPoint, PxRect, PxSize, TimeUnits as _, about_eq,
     about_eq_hash, about_eq_ord, euclid,
 };
+use zng_task::parking_lot::{Mutex, RwLock};
 use zng_task::{self as task, channel::IpcBytes};
 use zng_txt::Txt;
 use zng_var::{IntoVar, ResponseVar, Var, animation::Transitionable, const_var, impl_from_and_into_var, response_done_var, response_var};

--- a/crates/zng-ext-font/src/query_util.rs
+++ b/crates/zng-ext-font/src/query_util.rs
@@ -14,7 +14,7 @@ mod desktop {
         sync::Arc,
     };
 
-    use parking_lot::Mutex;
+    use zng_task::parking_lot::Mutex;
     use zng_var::ResponseVar;
 
     use crate::{FontBytes, FontLoadingError, FontName, FontStretch, FontStyle, FontWeight, GlyphLoadingError, WeakFontBytes};
@@ -296,7 +296,7 @@ mod android {
         })
     }
 
-    fn cached_system_all() -> parking_lot::MappedRwLockReadGuard<'static, Vec<(FontName, PathBuf)>> {
+    fn cached_system_all() -> zng_task::parking_lot::MappedRwLockReadGuard<'static, Vec<(FontName, PathBuf)>> {
         let lock = SYSTEM_ALL.read();
         if !lock.is_empty() {
             return lock;

--- a/crates/zng-ext-fs-watcher/Cargo.toml
+++ b/crates/zng-ext-fs-watcher/Cargo.toml
@@ -38,7 +38,6 @@ glob = { version = "0.3", default-features = false  }
 notify = { version = "8.0", default-features = false, features = ["macos_fsevent"] }
 path-absolutize = { version = "3.1", default-features = false }
 atomic = { version = "0.6", default-features = false, features = ["fallback"] }
-parking_lot = { version = "0.12", default-features = false }
 
 serde_json = { version = "1.0", optional = true, default-features = false, features = ["std"] }
 toml = { version = "1.0", optional = true, default-features = false, features = ["preserve_order", "display", "std", "serde", "parse"] }

--- a/crates/zng-ext-fs-watcher/src/lib.rs
+++ b/crates/zng-ext-fs-watcher/src/lib.rs
@@ -33,7 +33,6 @@ use std::{
     time::Duration,
 };
 
-use parking_lot::Mutex;
 use path_absolutize::Absolutize;
 use zng_app::{
     DInstant, INSTANT,
@@ -42,6 +41,7 @@ use zng_app::{
 };
 use zng_clone_move::clmv;
 use zng_handle::Handle;
+use zng_task::parking_lot::Mutex;
 use zng_txt::Txt;
 use zng_unit::TimeUnits;
 use zng_var::{AnyVar, BoxAnyVarValue, Var, VarHandle, VarValue, WeakAnyVar, var};

--- a/crates/zng-ext-fs-watcher/src/service.rs
+++ b/crates/zng-ext-fs-watcher/src/service.rs
@@ -1,11 +1,11 @@
 use std::{mem, path::PathBuf, sync::Arc, time::Duration};
 
-use parking_lot::{Condvar, Mutex};
 use zng_app::{
     APP, DInstant, INSTANT, hn_once,
     timer::{DeadlineHandle, TIMERS},
 };
 use zng_app_context::{LocalContext, app_local};
+use zng_task::parking_lot::{Condvar, Mutex};
 use zng_unit::TimeUnits;
 use zng_var::{Var, var};
 

--- a/crates/zng-ext-fs-watcher/src/service/watchers.rs
+++ b/crates/zng-ext-fs-watcher/src/service/watchers.rs
@@ -1,5 +1,4 @@
 use notify::Watcher as _;
-use parking_lot::Mutex;
 use std::{
     collections::{HashMap, hash_map},
     io, mem,
@@ -8,6 +7,7 @@ use std::{
 };
 use zng_handle::{Handle, HandleOwner};
 use zng_task::channel::{self, ChannelError};
+use zng_task::parking_lot::Mutex;
 use zng_unit::TimeUnits;
 
 use crate::{WatcherHandle, fs_event};

--- a/crates/zng-ext-image/Cargo.toml
+++ b/crates/zng-ext-image/Cargo.toml
@@ -31,7 +31,6 @@ zng-env = { path = "../zng-env", version = "0.11.3", default-features = false }
 
 serde = { version = "1.0", default-features = false }
 once_cell = { version = "1.19", default-features = false, features = ["parking_lot"] }
-parking_lot = { version = "0.12", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 base64 = { version = "0.22", default-features = false, features = ["std"] }
 dunce = { version = "1.0", default-features = false }

--- a/crates/zng-ext-image/src/lib.rs
+++ b/crates/zng-ext-image/src/lib.rs
@@ -17,7 +17,6 @@
 
 use std::{any::Any, path::PathBuf, pin::Pin};
 
-use parking_lot::Mutex;
 use zng_app::{
     static_id,
     update::UPDATES,
@@ -39,6 +38,7 @@ use zng_clone_move::clmv;
 use zng_layout::unit::{ByteLength, ByteUnits};
 use zng_state_map::StateId;
 use zng_task::channel::{IpcBytes, IpcReadHandle};
+use zng_task::parking_lot::Mutex;
 use zng_txt::ToTxt;
 use zng_unique_id::{IdEntry, IdMap};
 use zng_var::{IntoVar, Var, VarHandle, var};

--- a/crates/zng-ext-image/src/types.rs
+++ b/crates/zng-ext-image/src/types.rs
@@ -5,7 +5,6 @@ use std::{
     sync::Arc,
 };
 
-use parking_lot::Mutex;
 use zng_app::{
     view_process::{EncodeError, VIEW_PROCESS, ViewImageHandle, ViewRenderer},
     widget::node::UiNode,
@@ -19,6 +18,7 @@ use zng_layout::{
     context::{LAYOUT, LayoutMetrics, LayoutPassId},
     unit::{ByteLength, ByteUnits, FactorUnits as _, LayoutAxis, Px, PxDensity2d, PxLine, PxPoint, PxRect, PxSize, about_eq},
 };
+use zng_task::parking_lot::Mutex;
 use zng_task::{
     self as task,
     channel::{IpcBytes, IpcBytesMut, IpcReadHandle},

--- a/crates/zng-ext-input/Cargo.toml
+++ b/crates/zng-ext-input/Cargo.toml
@@ -31,7 +31,6 @@ zng-task = { path = "../zng-task", version = "0.13.4", default-features = false 
 zng-env = { path = "../zng-env", version = "0.11.3", default-features = false }
 
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-parking_lot = { version = "0.12", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 bitflags = { version = "2.5", default-features = false, features = ["serde", "bytemuck"] }
 atomic = { version = "0.6", default-features = false }

--- a/crates/zng-ext-input/src/drag_drop.rs
+++ b/crates/zng-ext-input/src/drag_drop.rs
@@ -21,7 +21,6 @@
 
 use std::mem;
 
-use parking_lot::Mutex;
 use zng_app::{
     event::{event, event_args},
     hn, static_id,
@@ -40,6 +39,7 @@ use zng_handle::{Handle, HandleOwner, WeakHandle};
 use zng_layout::unit::{DipPoint, DipToPx as _, PxToDip as _};
 use zng_state_map::StateId;
 use zng_task::channel::IpcBytes;
+use zng_task::parking_lot::Mutex;
 use zng_txt::{Txt, formatx};
 use zng_var::{ArcEq, Var, var};
 use zng_view_api::{DragDropId, mouse::ButtonState, touch::TouchPhase};

--- a/crates/zng-ext-input/src/focus/focus_info.rs
+++ b/crates/zng-ext-input/src/focus/focus_info.rs
@@ -2,7 +2,6 @@ use std::fmt;
 use std::sync::atomic::Ordering::Relaxed;
 
 use atomic::Atomic;
-use parking_lot::Mutex;
 use zng_app::{
     widget::{
         WidgetId,
@@ -13,6 +12,7 @@ use zng_app::{
 use zng_ext_window::NestedWindowWidgetInfoExt;
 use zng_layout::unit::{DistanceKey, Orientation2D, Px, PxBox, PxPoint, PxRect, PxSize};
 use zng_state_map::{StateId, static_id};
+use zng_task::parking_lot::Mutex;
 use zng_unique_id::IdSet;
 use zng_var::impl_from_and_into_var;
 use zng_view_api::window::FocusIndicator;

--- a/crates/zng-ext-input/src/gesture.rs
+++ b/crates/zng-ext-input/src/gesture.rs
@@ -9,7 +9,6 @@
 //!
 //! * [`GESTURES`]
 
-use parking_lot::Mutex;
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,
@@ -38,6 +37,7 @@ use zng_env::on_process_start;
 use zng_ext_window::WINDOWS;
 use zng_handle::{Handle, HandleOwner, WeakHandle};
 use zng_layout::unit::DipPoint;
+use zng_task::parking_lot::Mutex;
 use zng_var::{Var, var};
 use zng_view_api::{
     keyboard::{Key, KeyCode, KeyLocation, KeyState, NativeKeyCode},

--- a/crates/zng-ext-l10n/Cargo.toml
+++ b/crates/zng-ext-l10n/Cargo.toml
@@ -41,7 +41,6 @@ zng-env = { path = "../zng-env", version = "0.11.3", default-features = false }
 fluent = { version = "0.17", default-features = false }
 fluent-syntax = { version = "0.12", default-features = false }
 intl-memoizer = { version = "0.5", default-features = false }
-parking_lot = { version = "0.12", default-features = false }
 unic-langid = { version = "0.9", default-features = false }
 tracing = { version = "0.1", default-features = false }
 unicase = { version = "2.7", default-features = false }

--- a/crates/zng-ext-l10n/src/service.rs
+++ b/crates/zng-ext-l10n/src/service.rs
@@ -7,8 +7,8 @@ use std::{
     sync::Arc,
 };
 
-use parking_lot::Mutex;
 use zng_app_context::app_local;
+use zng_task::parking_lot::Mutex;
 use zng_txt::Txt;
 use zng_var::{ArcEq, MergeVarBuilder, Var, WeakVar, const_var, merge_var, var};
 use zng_view_api::config::LocaleConfig;

--- a/crates/zng-ext-l10n/src/usage_recorder.rs
+++ b/crates/zng-ext-l10n/src/usage_recorder.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, fs, io, path::PathBuf, sync::LazyLock};
 
-use parking_lot::Mutex;
+use zng_task::parking_lot::Mutex;
 use zng_txt::Txt;
 
 use crate::LangFilePath;

--- a/crates/zng-ext-single-instance/Cargo.toml
+++ b/crates/zng-ext-single-instance/Cargo.toml
@@ -18,7 +18,6 @@ zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 zng-task = { path = "../zng-task", version = "0.13.4", default-features = false }
 zng-ext-fs-watcher = { path = "../zng-ext-fs-watcher", version = "0.12.9", default-features = false }
 
-parking_lot = { version = "0.12", default-features = false }
 single-instance = { version = "0.3", default-features = false }
 tracing = { version = "0.1", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }

--- a/crates/zng-ext-single-instance/src/lib.rs
+++ b/crates/zng-ext-single-instance/src/lib.rs
@@ -128,7 +128,7 @@ struct SingleInstanceData {
     name: Txt,
 }
 
-static SINGLE_INSTANCE: parking_lot::Mutex<Option<SingleInstanceData>> = parking_lot::Mutex::new(None);
+static SINGLE_INSTANCE: zng_task::parking_lot::Mutex<Option<SingleInstanceData>> = zng_task::parking_lot::Mutex::new(None);
 
 impl SingleInstanceData {
     fn new(_lock: single_instance::SingleInstance, name: Txt) -> Self {

--- a/crates/zng-ext-window/Cargo.toml
+++ b/crates/zng-ext-window/Cargo.toml
@@ -39,7 +39,6 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 bitflags = { version = "2.5", default-features = false, features = ["serde", "bytemuck"] }
 atomic = { version = "0.6", default-features = false, features = ["fallback"] }
 tracing = { version = "0.1", default-features = false }
-parking_lot = { version = "0.12", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/zng-ext-window/src/window.rs
+++ b/crates/zng-ext-window/src/window.rs
@@ -1,6 +1,5 @@
 use std::{any::Any, mem, pin::Pin, sync::Arc};
 
-use parking_lot::Mutex;
 use zng_app::{
     APP, Deadline, async_hn_once,
     render::{FrameBuilder, FrameUpdate},
@@ -28,6 +27,7 @@ use zng_layout::{
     },
 };
 use zng_state_map::StateId;
+use zng_task::parking_lot::Mutex;
 use zng_txt::Txt;
 use zng_unique_id::IdSet;
 use zng_var::{ResponderVar, ResponseVar, VarHandle};

--- a/crates/zng-ext-window/src/windows.rs
+++ b/crates/zng-ext-window/src/windows.rs
@@ -1,6 +1,5 @@
 use std::{any::Any, mem, pin::Pin, sync::Arc};
 
-use parking_lot::Mutex;
 use zng_app::{
     APP, Deadline, hn_once,
     timer::TIMERS,
@@ -17,6 +16,7 @@ use zng_app::{
 };
 use zng_app_context::{RunOnDrop, app_local};
 use zng_layout::unit::FrequencyUnits;
+use zng_task::parking_lot::Mutex;
 use zng_task::{ParallelIteratorExt, rayon::prelude::*};
 use zng_txt::{ToTxt as _, Txt, formatx};
 use zng_unique_id::{IdEntry, IdMap, IdSet};

--- a/crates/zng-task/Cargo.toml
+++ b/crates/zng-task/Cargo.toml
@@ -12,10 +12,6 @@ categories = ["gui"]
 keywords = ["gui", "ui", "user-interface", "zng"]
 
 [features]
-
-# Enables parking_lot deadlock detection.
-deadlock_detection = ["parking_lot/deadlock_detection"]
-
 # Enables real worker processes and IPC channels.
 #
 # Only enables in `cfg(not(any(target_os = "android", target_arch = "wasm32", target_os = "ios")))` builds.
@@ -65,7 +61,7 @@ pretty-type-name = { version = "1.0", default-features = false }
 flume = { version = "0.12", default-features = false, features = ["async"] }
 rayon = { version = "1.10", default-features = false }
 blocking = { version = "1.5", default-features = false }
-parking_lot = { version = "0.12", default-features = false }
+parking_lot = { version = "0.12", default-features = false, features = ["arc_lock"] }
 futures-timer = { version = "3.0", default-features = false }
 futures-lite = { version = "2.3", default-features = false, features = ["std"] }
 # TODO(breaking) remove this and when async-fs can be used again

--- a/crates/zng-task/src/lib.rs
+++ b/crates/zng-task/src/lib.rs
@@ -22,10 +22,6 @@ use std::{
     task::Poll,
 };
 
-#[doc(no_inline)]
-pub use parking_lot; // TODO(breaking) don't reexport everything? Maybe in `zng` at least
-use parking_lot::Mutex;
-
 use zng_app_context::{LocalContext, app_local};
 use zng_time::Deadline;
 use zng_var::{ResponseVar, VarValue, response_done_var, response_var};
@@ -33,23 +29,24 @@ use zng_var::{ResponseVar, VarValue, response_done_var, response_var};
 #[cfg(test)]
 mod tests;
 
-#[doc(no_inline)]
-pub use rayon;
+mod reexports;
+pub use reexports::*;
+
+use crate::parking_lot::Mutex;
 
 pub mod channel;
 pub mod fs;
 pub mod io;
+
 mod ui;
+pub use ui::*;
 
 pub mod http;
 
 pub mod process;
 
 mod rayon_ctx;
-
 pub use rayon_ctx::*;
-
-pub use ui::*;
 
 mod progress;
 pub use progress::*;

--- a/crates/zng-task/src/reexports.rs
+++ b/crates/zng-task/src/reexports.rs
@@ -1,0 +1,21 @@
+/// Recommended blocking lock primitives.
+///
+/// The `Mutex` and `RwLock` types reexported here are recommended, they are
+/// more optimized than `std` alternatives because they don't implement lock poisoning,
+/// have `const` initialization and integrate with the `zng` feature `"deadlock_detection"`.
+///
+/// # Full API
+///
+/// See the [`parking_lot`] crate for the full API.
+///
+/// [`parking_lot`]: https://docs.rs/parking_lot
+pub mod parking_lot {
+    #[doc(no_inline)]
+    pub use ::parking_lot::{
+        ArcMutexGuard, ArcRwLockReadGuard, ArcRwLockWriteGuard, Condvar, MappedMutexGuard, MappedRwLockReadGuard, MappedRwLockWriteGuard,
+        Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard,
+    };
+}
+
+#[doc(no_inline)]
+pub use rayon;

--- a/crates/zng-view-api/Cargo.toml
+++ b/crates/zng-view-api/Cargo.toml
@@ -45,7 +45,6 @@ bitflags = { version = "2.5", default-features = false, features = ["serde", "by
 bytemuck = { version = "1.15", default-features = false, features = ["derive"] }
 
 postcard = { version = "1", default-features = false, features = ["alloc"] }
-parking_lot = { version = "0.12", default-features = false }
 serde_variant = { version = "0.1", default-features = false }
 
 unic-langid = { version = "0.9", features = ["serde"] }

--- a/crates/zng-view-api/src/app_process.rs
+++ b/crates/zng-view-api/src/app_process.rs
@@ -9,8 +9,8 @@ use std::{
 
 use std::time::Duration;
 
-use parking_lot::Mutex;
 use zng_task::channel::ChannelError;
+use zng_task::parking_lot::Mutex;
 use zng_txt::Txt;
 
 use crate::{

--- a/crates/zng-view-api/src/ipc.rs
+++ b/crates/zng-view-api/src/ipc.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use crate::{AnyResult, Event, Request, Response};
 
-use parking_lot::Mutex;
 use zng_task::channel::{self, ChannelError, IpcReceiver, IpcSender};
+use zng_task::parking_lot::Mutex;
 use zng_txt::Txt;
 
 type AppInitMsg = (

--- a/crates/zng-view-api/src/view_process.rs
+++ b/crates/zng-view-api/src/view_process.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 #[cfg(target_arch = "wasm32")]
 use web_time::Instant;
 
-use parking_lot::Mutex;
+use zng_task::parking_lot::Mutex;
 use zng_txt::Txt;
 
 use crate::{VIEW_MODE, VIEW_SERVER, VIEW_VERSION};

--- a/crates/zng-view/Cargo.toml
+++ b/crates/zng-view/Cargo.toml
@@ -292,7 +292,6 @@ version = "0.2"
 features = ["std"]
 
 [target.'cfg(target_os = "android")'.dependencies]
-parking_lot = { version = "0.12", default-features = false }
 # matches winit -> android-activity
 ndk = { version = "0.9.0", default-features = false }
 ndk-context = { version = "0.1.1", default-features = false }

--- a/crates/zng-view/src/platform.rs
+++ b/crates/zng-view/src/platform.rs
@@ -9,7 +9,7 @@ pub mod android {
     pub use winit::platform::android::activity;
 
     #[cfg(target_os = "android")]
-    static ANDROID_APP: parking_lot::RwLock<Option<activity::AndroidApp>> = parking_lot::RwLock::new(None);
+    static ANDROID_APP: zng_task::parking_lot::RwLock<Option<activity::AndroidApp>> = zng_task::parking_lot::RwLock::new(None);
 
     /// Sets the [`android_app`] instance for this process and the Android paths.
     ///

--- a/crates/zng-wgt-data/src/lib.rs
+++ b/crates/zng-wgt-data/src/lib.rs
@@ -743,7 +743,7 @@ pub fn with_data_notes(child: impl IntoUiNode, mut on_changed: impl FnMut(&DataN
 
             let cleaned = notes.notes.cleanup();
             if mem::take(&mut notes.changed) || cleaned {
-                let notes = task::parking_lot::lock_api::RwLockWriteGuard::downgrade(notes);
+                let notes = task::parking_lot::RwLockWriteGuard::downgrade(notes);
                 let notes = &notes.notes;
 
                 if !DATA_NOTES_CTX.is_default() {


### PR DESCRIPTION
Reexporting the full crate causes some weird auto-complete suggestions.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->