### PR TITLE
Refactor `zng::task::rayon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* **Breaking** `ParallelIteratorExt` and related types moved to `zng::task::rayon`.
+* **Breaking** `zng::task::rayon` now only reexports primary traits.
 * **Breaking** `zng::task::parking_lot` now only reexports primary types.
 * **Breaking** `Label!` no longer inherits `FocusableMix`.
 * Add `WINDOW_Ext as _` to `zng::prelude_wgt`.

--- a/crates/zng-app/src/widget/node/list.rs
+++ b/crates/zng-app/src/widget/node/list.rs
@@ -17,12 +17,11 @@ use crate::{
         info::{WidgetInfo, WidgetInfoBuilder, WidgetLayout, WidgetMeasure},
     },
 };
-use task::ParallelIteratorExt;
 use zng_app_context::context_local;
 use zng_layout::unit::{Factor, PxSize, PxTransform, PxVector};
 use zng_state_map::StateId;
 use zng_task::parking_lot::Mutex;
-use zng_task::{self as task, rayon::prelude::*};
+use zng_task::rayon::prelude::*;
 use zng_unique_id::static_id;
 use zng_var::{animation::Transitionable, impl_from_and_into_var};
 

--- a/crates/zng-ext-window/src/windows.rs
+++ b/crates/zng-ext-window/src/windows.rs
@@ -17,7 +17,7 @@ use zng_app::{
 use zng_app_context::{RunOnDrop, app_local};
 use zng_layout::unit::FrequencyUnits;
 use zng_task::parking_lot::Mutex;
-use zng_task::{ParallelIteratorExt, rayon::prelude::*};
+use zng_task::rayon::prelude::*;
 use zng_txt::{ToTxt as _, Txt, formatx};
 use zng_unique_id::{IdEntry, IdMap, IdSet};
 use zng_var::{ResponderVar, ResponseVar, VARS, Var, const_var, response_done_var, response_var, var, var_default};

--- a/crates/zng-task/src/lib.rs
+++ b/crates/zng-task/src/lib.rs
@@ -46,7 +46,6 @@ pub mod http;
 pub mod process;
 
 mod rayon_ctx;
-pub use rayon_ctx::*;
 
 mod progress;
 pub use progress::*;
@@ -184,7 +183,7 @@ struct RayonTask {
 }
 impl RayonTask {
     fn poll(self: Arc<Self>) {
-        rayon::spawn(move || {
+        ::rayon::spawn(move || {
             // this `Option<Fut>` dance is used to avoid a `poll` after `Ready` or panic.
             let mut task = self.fut.lock();
             if let Some(mut t) = task.take() {
@@ -243,14 +242,14 @@ where
 /// [`LocalContext`]: zng_app_context::LocalContext
 pub fn join_context<A, B, RA, RB>(op_a: A, op_b: B) -> (RA, RB)
 where
-    A: FnOnce(rayon::FnContext) -> RA + Send,
-    B: FnOnce(rayon::FnContext) -> RB + Send,
+    A: FnOnce(::rayon::FnContext) -> RA + Send,
+    B: FnOnce(::rayon::FnContext) -> RB + Send,
     RA: Send,
     RB: Send,
 {
     let ctx = LocalContext::capture();
     let ctx = &ctx;
-    rayon::join_context(
+    ::rayon::join_context(
         move |a| {
             if a.migrated() {
                 ctx.clone().with_context(|| op_a(a))
@@ -292,7 +291,7 @@ where
     let ctx_ref: &'_ LocalContext = &ctx;
     let ctx_scope_ref: &'scope LocalContext = unsafe { std::mem::transmute(ctx_ref) };
 
-    let r = rayon::scope(move |s| {
+    let r = ::rayon::scope(move |s| {
         op(ScopeCtx {
             scope: s,
             ctx: ctx_scope_ref,
@@ -309,7 +308,7 @@ where
 /// See [`scope`] for more details.
 #[derive(Clone, Copy, Debug)]
 pub struct ScopeCtx<'a, 'scope: 'a> {
-    scope: &'a rayon::Scope<'scope>,
+    scope: &'a ::rayon::Scope<'scope>,
     ctx: &'scope LocalContext,
 }
 impl<'a, 'scope: 'a> ScopeCtx<'a, 'scope> {
@@ -424,7 +423,7 @@ where
             if sender.is_disconnected() {
                 return; // cancel.
             }
-            rayon::spawn(move || {
+            ::rayon::spawn(move || {
                 // this `Option<Fut>` dance is used to avoid a `poll` after `Ready` or panic.
                 let mut task = self.fut.lock();
                 if let Some(mut t) = task.take() {
@@ -528,7 +527,7 @@ where
             if responder.strong_count() == 2 {
                 return; // cancel.
             }
-            rayon::spawn(move || {
+            ::rayon::spawn(move || {
                 // this `Option<Fut>` dance is used to avoid a `poll` after `Ready` or panic.
                 let mut task = self.fut.lock();
                 if let Some(mut t) = task.take() {

--- a/crates/zng-task/src/reexports.rs
+++ b/crates/zng-task/src/reexports.rs
@@ -1,4 +1,4 @@
-/// Recommended blocking lock primitives.
+/// Recommended blocking locks.
 ///
 /// The `Mutex` and `RwLock` types reexported here are recommended, they are
 /// more optimized than `std` alternatives because they don't implement lock poisoning,
@@ -17,5 +17,35 @@ pub mod parking_lot {
     };
 }
 
-#[doc(no_inline)]
-pub use rayon;
+/// Parallel iterators.
+///
+/// This module mostly reexports the primary traits from the [`rayon`] crate.
+///
+/// This module also includes [`ParallelIteratorWithCtx`] that propagates the
+/// zng app context to rayon tasks.
+///
+/// # Full API
+///
+/// See the [`rayon`] crate for the full API.
+///
+/// [`rayon`]: https://docs.rs/rayon
+/// [`ParallelIteratorWithCtx`]: crate::rayon::ParallelIteratorWithCtx
+pub mod rayon {
+    #[doc(no_inline)]
+    pub use ::rayon::{iter, slice, str};
+
+    pub use crate::rayon_ctx::*;
+
+    /// Rayon traits imported `as _`.
+    pub mod prelude {
+        #[doc(no_inline)]
+        pub use ::rayon::{
+            iter::FromParallelIterator as _, iter::IndexedParallelIterator as _, iter::IntoParallelIterator as _,
+            iter::IntoParallelRefIterator as _, iter::IntoParallelRefMutIterator as _, iter::ParallelBridge as _,
+            iter::ParallelDrainFull as _, iter::ParallelDrainRange as _, iter::ParallelExtend as _, iter::ParallelIterator as _,
+            slice::ParallelSlice as _, slice::ParallelSliceMut as _, str::ParallelString as _,
+        };
+
+        pub use super::ParallelIteratorExt as _;
+    }
+}

--- a/crates/zng-task/src/tests.rs
+++ b/crates/zng-task/src/tests.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use rayon::prelude::*;
+use crate::rayon::prelude::*;
 
 use super::*;
 use zng_unit::TimeUnits;

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -561,11 +561,7 @@ pub mod prelude {
 mod __prelude {
     pub use crate::{color, gesture, keyboard, layout, mouse, task, timer, touch, widget};
 
-    pub use zng_task::rayon::prelude::{
-        FromParallelIterator as _, IndexedParallelIterator as _, IntoParallelIterator as _, IntoParallelRefIterator as _,
-        IntoParallelRefMutIterator as _, ParallelBridge as _, ParallelDrainFull as _, ParallelDrainRange as _, ParallelExtend as _,
-        ParallelIterator as _, ParallelSlice as _, ParallelSliceMut as _, ParallelString as _,
-    };
+    pub use zng_task::rayon::prelude::*;
 
     pub use zng_task::io::{
         AsyncBufRead as _, AsyncRead as _, AsyncReadExt as _, AsyncSeek as _, AsyncSeekExt as _, AsyncWrite as _, AsyncWriteExt as _,

--- a/crates/zng/src/task.rs
+++ b/crates/zng/src/task.rs
@@ -6,8 +6,10 @@
 //! All functions of this module propagate the [`LocalContext`].
 //!
 //! This crate also re-exports the [`rayon`] and [`parking_lot`] crates for convenience. You can use the
-//! [`ParallelIteratorExt::with_ctx`] adapter in rayon iterators to propagate the [`LocalContext`]. You can
+//! [`with_ctx`] adapter in rayon iterators to propagate the [`LocalContext`]. You can
 //! also use [`join`] to propagate thread context for a raw rayon join operation.
+//!
+//! [`with_ctx`]: crate::task::rayon::ParallelIteratorExt::with_ctx
 //!
 //! # Examples
 //!
@@ -144,9 +146,9 @@
 //! See [`zng_task`] for the full API.
 
 pub use zng_task::{
-    DeadlineError, McWaker, ParallelIteratorExt, ParallelIteratorWithCtx, Progress, ScopeCtx, SignalOnce, TaskPanicError, UiTask, all,
-    all_ok, all_some, any, any_ok, any_some, block_on, deadline, fs, future_fn, io, join, join_context, poll_respond, poll_spawn, respond,
-    run, run_catch, scope, set_spawn_panic_handler, spawn, spawn_wait, wait, wait_catch, wait_respond, with_deadline, yield_now,
+    DeadlineError, McWaker, Progress, ScopeCtx, SignalOnce, TaskPanicError, UiTask, all, all_ok, all_some, any, any_ok, any_some, block_on,
+    deadline, fs, future_fn, io, join, join_context, poll_respond, poll_spawn, respond, run, run_catch, scope, set_spawn_panic_handler,
+    spawn, spawn_wait, wait, wait_catch, wait_respond, with_deadline, yield_now,
 };
 
 #[cfg(any(doc, feature = "test_util"))]
@@ -235,7 +237,63 @@ pub mod channel {
 #[cfg(ipc)]
 pub use zng_task::process;
 
-#[doc(no_inline)]
-pub use zng_task::{parking_lot, rayon};
-
 pub use zng_app::widget::UiTaskWidget;
+
+/// Recommended blocking locks.
+///
+/// The `Mutex` and `RwLock` types reexported here are recommended, they are
+/// more optimized than `std` alternatives because they don't implement lock poisoning,
+/// have `const` initialization and integrate with the `zng` feature `"deadlock_detection"`.
+///
+/// # Full API
+///
+/// See the [`parking_lot`] crate for the full API.
+///
+/// [`parking_lot`]: https://docs.rs/parking_lot
+pub mod parking_lot {
+    use zng_task::parking_lot;
+
+    // no_inline is not imported from zng_task
+    #[doc(no_inline)]
+    pub use parking_lot::{
+        ArcMutexGuard, ArcRwLockReadGuard, ArcRwLockWriteGuard, Condvar, MappedMutexGuard, MappedRwLockReadGuard, MappedRwLockWriteGuard,
+        Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard,
+    };
+}
+
+/// Parallel iterators.
+///
+/// This module mostly reexports the primary traits from the [`rayon`] crate.
+///
+/// This module also includes [`ParallelIteratorWithCtx`] that propagates the
+/// zng app context to rayon tasks.
+///
+/// # Full API
+///
+/// See the [`rayon`] crate for the full API.
+///
+/// [`rayon`]: https://docs.rs/rayon
+/// [`ParallelIteratorWithCtx`]: crate::task::rayon::ParallelIteratorWithCtx
+pub mod rayon {
+    pub use zng_task::rayon::{ParallelIteratorExt, ParallelIteratorWithCtx};
+
+    use zng_task::rayon;
+
+    #[doc(no_inline)]
+    pub use rayon::{iter, slice, str};
+
+    /// Rayon traits imported `as _`.
+    pub mod prelude {
+        use zng_task::rayon;
+
+        #[doc(no_inline)]
+        pub use rayon::{
+            iter::FromParallelIterator as _, iter::IndexedParallelIterator as _, iter::IntoParallelIterator as _,
+            iter::IntoParallelRefIterator as _, iter::IntoParallelRefMutIterator as _, iter::ParallelBridge as _,
+            iter::ParallelDrainFull as _, iter::ParallelDrainRange as _, iter::ParallelExtend as _, iter::ParallelIterator as _,
+            slice::ParallelSlice as _, slice::ParallelSliceMut as _, str::ParallelString as _,
+        };
+
+        pub use zng_task::rayon::ParallelIteratorExt as _;
+    }
+}

--- a/examples/extend-view/Cargo.toml
+++ b/examples/extend-view/Cargo.toml
@@ -14,6 +14,7 @@ tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 raw-window-handle = "0.6"
 zng-wgt-webrender-debug = { path = "../../crates/zng-wgt-webrender-debug" }
+rayon = { version = "1.10", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 zng-view-angle = { path = "../../crates/zng-view-angle", features = ["download"] }

--- a/examples/extend-view/src/using_blob.rs
+++ b/examples/extend-view/src/using_blob.rs
@@ -393,7 +393,7 @@ pub mod view_side {
         task_keys: HashMap<BlobImageKey, usize>,
         task_params: HashMap<CustomTaskParams, usize>,
         single_threaded: bool,
-        workers: Option<Arc<zng::prelude::task::rayon::ThreadPool>>,
+        workers: Option<Arc<rayon::ThreadPool>>,
     }
 
     #[derive(PartialEq, Eq, Hash, Clone, Copy)]


### PR DESCRIPTION
It does not need to reexport the full crate. It now also includes the zng extensions for rayon.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->