### PR TITLE
Convert `rich_text` property to build action

### DIFF
--- a/crates/zng-view-api/src/lib.rs
+++ b/crates/zng-view-api/src/lib.rs
@@ -274,7 +274,6 @@ declare_api! {
     ///
     /// Other methods may only be called after this event.
     fn init(&mut self, vp_gen: ViewProcessGen, is_respawn: bool, headless: bool);
-    // TODO(breaking) non_exhaustive init args
 
     /// Called once after exit, if running in a managed external process it will be killed after this call.
     fn exit(&mut self);

--- a/crates/zng-wgt-text/src/node/rich.rs
+++ b/crates/zng-wgt-text/src/node/rich.rs
@@ -22,7 +22,6 @@ use super::{RICH_TEXT, RichCaretInfo, RichText, TEXT};
 
 pub(crate) fn rich_text_node(child: impl IntoUiNode, enabled: impl IntoVar<bool>) -> UiNode {
     let enabled = enabled.into_var();
-    let child = rich_text_events_broadcast(child);
     let child = rich_text_cmds(child);
     let child = rich_text_component(child, "rich_text");
 
@@ -158,7 +157,7 @@ fn rich_text_cmds(child: impl IntoUiNode) -> UiNode {
 // some visuals (like selection background) depend on focused status of any rich leaf
 //
 // leaf texts also handle pointer input events for the rich text
-fn rich_text_events_broadcast(child: impl IntoUiNode) -> UiNode {
+pub(crate) fn rich_text_events_broadcast(child: impl IntoUiNode) -> UiNode {
     let mut handles = VarHandles::dummy();
     match_node(child, move |c, op| {
         match op {

--- a/crates/zng-wgt-text/src/text_properties.rs
+++ b/crates/zng-wgt-text/src/text_properties.rs
@@ -2121,9 +2121,13 @@ impl RichTextMix<()> {
 /// clipping the caret.
 ///
 /// When enabled and not nested the widget will handle text commands, it also broadcasts focus change events to all text descendants.
-#[property(CONTEXT + 1, default(false), widget_impl(RichTextMix<P>))] // + 1 because it needs to read TEXT_SELECTABLE_VAR
-pub fn rich_text(child: impl IntoUiNode, enabled: impl IntoVar<bool>) -> UiNode {
-    crate::node::rich_text_node(child, enabled) // TODO(breaking) refactor into a build action property
+#[property(CONTEXT, default(false), widget_impl(RichTextMix<P>))]
+pub fn rich_text(wgt: &mut WidgetBuilding, enabled: impl IntoVar<bool>) {
+    let enabled = enabled.into_var();
+    // CONTEXT to stablish the `TEXT.rich` context
+    wgt.push_intrinsic(NestGroup::CONTEXT, "rich_text", move |c| crate::node::rich_text_node(c, enabled));
+    // EVENT to access TEXT_SELECTABLE_VAR context reliably
+    wgt.push_intrinsic(NestGroup::EVENT, "rich_text_broadcast", crate::node::rich_text_events_broadcast);
 }
 
 /// Defines the Z-index set on inner text (and nested rich text) widgets when focus is within.


### PR DESCRIPTION
This property needs to access multiple nest groups data for optimal integration

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->