### PR TITLE
Add minimal video API

### DIFF
--- a/crates/zng-view-api/src/audio.rs
+++ b/crates/zng-view-api/src/audio.rs
@@ -1,4 +1,4 @@
-//! Audio device types.
+//! Audio types.
 
 use std::{num::NonZeroU16, time::Duration};
 
@@ -108,7 +108,7 @@ pub enum BufferSize {
     Unknown,
 }
 
-/// Represent an audio load/decode request.
+/// Represents an audio load/decode request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct AudioRequest<D> {

--- a/crates/zng-view-api/src/lib.rs
+++ b/crates/zng-view-api/src/lib.rs
@@ -45,6 +45,7 @@ pub mod menu;
 pub mod mouse;
 pub mod raw_input;
 pub mod touch;
+pub mod video;
 pub mod window;
 
 mod types;
@@ -436,9 +437,24 @@ declare_api! {
     /// [`Event::ImageEncoded`] or [`Event::ImageEncodeError`]. The returned ID identifies this request.
     pub fn encode_image(&mut self, request: image::ImageEncodeRequest) -> image::ImageEncodeId;
 
+    /// Under development, see [`video`].
+    pub fn add_video(&mut self, request: video::VideoRequest<IpcReadHandle>) -> video::VideoId;
+
+    /// Under development, see [`video`].
+    pub fn add_video_pro(&mut self, request: video::VideoRequest<IpcReceiver<IpcBytes>>) -> video::VideoId;
+
+    /// Under development, see [`video`].
+    pub fn forget_video(&mut self, id: video::VideoId);
+
+    /// Under development, see [`video`].
+    pub fn use_video(&mut self, id: WindowId, video_id: video::VideoId) -> video::VideoTextureId;
+
+    /// Under development, see [`video`].
+    pub fn delete_video_use(&mut self, id: WindowId, texture_id: video::VideoTextureId);
+
     /// Cache an audio resource.
     ///
-    /// The entire audio source is already loaded in the request, it may be fully decode or decoded on demand depending on the request
+    /// The entire audio source is already loaded in the request, it may be decoded fully or on demand depending on the request,
     /// the returned ID can be played as soon as it starts decoding.
     ///
     /// The events [`Event::AudioMetadataDecoded`], [`Event::AudioDecoded`] and [`Event::AudioDecodeError`] will be send while decoding.

--- a/crates/zng-view-api/src/video.rs
+++ b/crates/zng-view-api/src/video.rs
@@ -1,0 +1,64 @@
+//! Video types.
+//!
+//! # Under Development
+//!
+//! This API is not ready yet, the types here are only the basics to
+//! avoid a breaking change release when video is implemented.
+
+use serde::{Deserialize, Serialize};
+use zng_txt::Txt;
+
+crate::declare_id! {
+    /// Id of a decoded or streaming video in the cache.
+    ///
+    /// The View Process defines the ID.
+    pub struct VideoId(_);
+
+    /// Id of a video playing in a renderer.
+    ///
+    /// The View Process defines the ID.
+    pub struct VideoTextureId(_);
+
+    /// Id of a video encode task.
+    ///
+    /// The View Process defines the ID.
+    pub struct VideoEncodeId(_);
+}
+
+/// Represents a video load/decode request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct VideoRequest<D> {
+    /// Video data format.
+    pub format: VideoDataFormat,
+
+    /// Video data.
+    ///
+    /// Bytes layout depends on the `format`, data structure is [`IpcReadHandle`] or [`IpcReceiver<IpcBytes>`] in the view API.
+    ///
+    /// [`IpcReadHandle`]: zng_task::channel::IpcReadHandle
+    /// [`IpcReceiver<IpcBytes>`]: zng_task::channel::IpcReceiver
+    pub data: D,
+}
+
+/// Format of the video bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum VideoDataFormat {
+    /// The video is encoded.
+    ///
+    /// This file extension maybe identifies the format. Fallback to `Unknown` handling if the file extension
+    /// is unknown or the file header does not match.
+    FileExtension(Txt),
+
+    /// The video is encoded.
+    ///
+    /// This MIME type maybe identifies the format. Fallback to `Unknown` handling if the file extension
+    /// is unknown or the file header does not match.
+    MimeType(Txt),
+
+    /// The image is encoded.
+    ///
+    /// A decoder will be selected using the "magic number" at the start of the bytes buffer.
+    Unknown,
+}

--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -2271,6 +2271,30 @@ impl Api for App {
         audio::AudioEncodeId::INVALID
     }
 
+    fn add_video(&mut self, request: video::VideoRequest<IpcReadHandle>) -> video::VideoId {
+        let _ = request;
+        video::VideoId::INVALID
+    }
+
+    fn add_video_pro(&mut self, request: video::VideoRequest<IpcReceiver<IpcBytes>>) -> video::VideoId {
+        let _ = request;
+        video::VideoId::INVALID
+    }
+
+    fn forget_video(&mut self, id: video::VideoId) {
+        let _ = id;
+    }
+
+    fn use_video(&mut self, id: WindowId, video_id: video::VideoId) -> video::VideoTextureId {
+        let _ = (id, video_id);
+        video::VideoTextureId::INVALID
+    }
+
+    /// Under development, see [`video`].
+    fn delete_video_use(&mut self, id: WindowId, texture_id: video::VideoTextureId) {
+        let _ = (id, texture_id);
+    }
+
     fn add_font_face(&mut self, id: WindowId, bytes: font::IpcFontBytes, index: u32) -> FontFaceId {
         with_window_or_surface!(self, id, |w| w.add_font_face(bytes, index), || FontFaceId::INVALID)
     }


### PR DESCRIPTION
This should be enough to implement video in 0.23

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->