### PR TITLE
Disable macOS "zoom" with `can_fullscreen`, not `can_maximize`

### DIFF
--- a/crates/zng-view/src/lib.rs
+++ b/crates/zng-view/src/lib.rs
@@ -1894,7 +1894,13 @@ impl Api for App {
             // Winit says "not implemented" for Wayland/x11 so may be in the future?
             info.window |= WindowCapability::SET_CAN_CLOSE;
             info.window |= WindowCapability::SET_CAN_MINIMIZE;
-            info.window |= WindowCapability::SET_CAN_MAXIMIZE;
+
+            if cfg!(target_os = "macos") {
+                info.window |= WindowCapability::SET_CAN_FULLSCREEN;
+            }
+            if cfg!(target_os = "windows") {
+                info.window |= WindowCapability::SET_CAN_MAXIMIZE;
+            }
         }
         info.window |= WindowCapability::SET_IME_AREA;
 

--- a/crates/zng-view/src/window.rs
+++ b/crates/zng-view/src/window.rs
@@ -1361,14 +1361,21 @@ impl Window {
     pub fn set_can_minimize(&self, can: bool) {
         self.set_enabled_button(WindowButtons::MINIMIZE, can);
     }
+    // winit disables the "zoom" (fullscreen mode) for MAXIMIZE in macos
+    // https://github.com/rust-windowing/winit/blob/81b272976588c767954df51b26999723fdb7cab4/winit-appkit/src/window_delegate.rs#L1208
     pub fn set_can_maximize(&self, can: bool) {
+        #[cfg(not(target_os = "macos"))]
         self.set_enabled_button(WindowButtons::MAXIMIZE, can);
+        let _ = can;
     }
-    pub fn set_can_fullscreen(&self, _can: bool) {}
+    pub fn set_can_fullscreen(&self, can: bool) {
+        #[cfg(target_os = "macos")]
+        self.set_enabled_button(WindowButtons::MAXIMIZE, can);
+        let _ = can;
+    }
     pub fn set_can_close(&self, can: bool) {
         self.set_enabled_button(WindowButtons::CLOSE, can);
     }
-
     fn set_enabled_button(&self, btn: WindowButtons, can: bool) {
         let mut buttons = self.window.enabled_buttons();
         buttons.set(btn, can);


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->