### PR TITLE
Optimize crash-handler-process stdout/err capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Fix `zng::task::process` not included when `"ipc"` feature is not enabled.
+    - Now only `zng::task::process::worker` is `"ipc"` conditional, as intended.
+* Add `zng::task::process::tap` for capturing and propagating child process output.
+* Optimized crash-handler-process stdout/err capture.
 * Add `MergeVarBuilder::join_txt`.
 
 # 0.23.1

--- a/crates/zng-app/src/crash_handler.rs
+++ b/crates/zng-app/src/crash_handler.rs
@@ -9,14 +9,14 @@
 
 use std::{
     fmt,
-    io::{BufRead, Write},
+    io::BufRead,
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicBool},
     time::SystemTime,
 };
 use zng_clone_move::clmv;
 use zng_layout::unit::TimeUnits as _;
-use zng_task::parking_lot::Mutex;
+use zng_task::{parking_lot::Mutex, process::tap};
 
 use zng_txt::{ToTxt as _, Txt};
 
@@ -869,7 +869,7 @@ fn crash_handler_monitor_process(
                 .env(APP_PROCESS, format!("restart-{}", dialog_args.app_crashes.len()))
                 .args(args.iter()),
         ) {
-            Ok((status, [stdout, stderr], dump_file)) => {
+            Ok((status, stdout, stderr, dump_file)) => {
                 if status.success() {
                     let code = status.code().unwrap_or(0);
                     tracing::info!(
@@ -919,8 +919,8 @@ fn crash_handler_monitor_process(
                         timestamp,
                         code,
                         signal,
-                        stdout.into(),
-                        stderr.into(),
+                        stdout.into_txt_blocking(),
+                        stderr.into_txt_blocking(),
                         dump_file,
                         args.clone(),
                     ));
@@ -972,7 +972,12 @@ fn crash_handler_monitor_process(
                             }
                             run_process(dump_dir.as_deref(), dialog_process.env(DIALOG_PROCESS, &crash_file))
                         } else {
-                            Ok((std::process::ExitStatus::default(), [String::new(), String::new()], None))
+                            Ok((
+                                std::process::ExitStatus::default(),
+                                tap::StdoutTap::null(),
+                                tap::StderrTap::null(),
+                                None,
+                            ))
                         };
 
                         for _ in 0..5 {
@@ -983,8 +988,9 @@ fn crash_handler_monitor_process(
                         }
 
                         let response = match dialog_result {
-                            Ok((dlg_status, [dlg_stdout, dlg_stderr], dlg_dump_file)) => {
+                            Ok((dlg_status, dlg_stdout, dlg_stderr, dlg_dump_file)) => {
                                 if dlg_status.success() {
+                                    let dlg_stdout = dlg_stdout.into_string_blocking();
                                     dlg_stdout
                                         .lines()
                                         .filter_map(|l| l.trim().strip_prefix(RESPONSE_PREFIX))
@@ -1024,8 +1030,8 @@ fn crash_handler_monitor_process(
                                         SystemTime::now(),
                                         code,
                                         signal,
-                                        dlg_stdout.into(),
-                                        dlg_stderr.into(),
+                                        dlg_stdout.into_txt_blocking(),
+                                        dlg_stderr.into_txt_blocking(),
                                         dlg_dump_file,
                                         Box::new([]),
                                     );
@@ -1063,7 +1069,7 @@ fn crash_handler_monitor_process(
 fn run_process(
     dump_dir: Option<&Path>,
     command: &mut std::process::Command,
-) -> std::io::Result<(std::process::ExitStatus, [String; 2], Option<PathBuf>)> {
+) -> std::io::Result<(std::process::ExitStatus, tap::StdoutTap, tap::StderrTap, Option<PathBuf>)> {
     struct DumpServer {
         shutdown: Arc<AtomicBool>,
         runner: std::thread::JoinHandle<Option<PathBuf>>,
@@ -1113,19 +1119,10 @@ fn run_process(
         .stderr(std::process::Stdio::piped())
         .spawn()?;
 
-    let stdout = capture_and_print(app_process.stdout.take().unwrap(), false);
-    let stderr = capture_and_print(app_process.stderr.take().unwrap(), true);
+    let stdout = tap::StdoutTap::new_blocking(app_process.stdout.take().unwrap());
+    let stderr = tap::StderrTap::new_blocking(app_process.stderr.take().unwrap());
 
     let status = app_process.wait()?;
-
-    let stdout = match stdout.join() {
-        Ok(r) => r,
-        Err(p) => std::panic::resume_unwind(p),
-    };
-    let stderr = match stderr.join() {
-        Ok(r) => r,
-        Err(p) => std::panic::resume_unwind(p),
-    };
 
     let mut dump_file = None;
     if let Some(s) = dump_server {
@@ -1136,7 +1133,7 @@ fn run_process(
         };
     }
 
-    Ok((status, [stdout, stderr], dump_file))
+    Ok((status, stdout, stderr, dump_file))
 }
 struct MinidumpServerHandler {
     dump_file: PathBuf,
@@ -1173,40 +1170,6 @@ impl minidumper::ServerHandler for MinidumpServerHandler {
         }
         minidumper::LoopAction::Exit
     }
-}
-fn capture_and_print(mut stream: impl std::io::Read + Send + 'static, is_err: bool) -> std::thread::JoinHandle<String> {
-    std::thread::Builder::new()
-        .name(format!("{}-reader", if is_err { "stderr" } else { "stdout" }))
-        .stack_size(256 * 1024)
-        .spawn(move || {
-            let mut capture = vec![];
-            let mut buffer = [0u8; 32];
-            loop {
-                match stream.read(&mut buffer) {
-                    Ok(n) => {
-                        if n == 0 {
-                            break;
-                        }
-
-                        let new = &buffer[..n];
-                        capture.write_all(new).unwrap();
-                        let r = if is_err {
-                            let mut s = std::io::stderr();
-                            s.write_all(new).and_then(|_| s.flush())
-                        } else {
-                            let mut s = std::io::stdout();
-                            s.write_all(new).and_then(|_| s.flush())
-                        };
-                        if let Err(e) = r {
-                            panic!("{} write error, {}", if is_err { "stderr" } else { "stdout" }, e)
-                        }
-                    }
-                    Err(e) => panic!("{} read error, {}", if is_err { "stderr" } else { "stdout" }, e),
-                }
-            }
-            String::from_utf8_lossy(&capture).into_owned()
-        })
-        .expect("failed to spawn thread")
 }
 
 fn crash_handler_app_process(dump_enabled: bool) {

--- a/crates/zng-task/src/lib.rs
+++ b/crates/zng-task/src/lib.rs
@@ -730,9 +730,6 @@ where
 
 /// Blocks the thread until the `task` future finishes.
 ///
-/// This function is useful for implementing async tests, using it in an app will probably cause
-/// the app to stop responding.
-///
 /// The crate [`futures-lite`] is used to execute the task.
 ///
 /// # Examples

--- a/crates/zng-task/src/process.rs
+++ b/crates/zng-task/src/process.rs
@@ -7,5 +7,7 @@
 #[cfg(ipc)]
 pub mod worker;
 
+pub mod tap;
+
 #[doc(no_inline)]
 pub use async_process::*;

--- a/crates/zng-task/src/process/tap.rs
+++ b/crates/zng-task/src/process/tap.rs
@@ -1,0 +1,232 @@
+//! Helper types for recording stdout/err while still passing through.
+
+use std::{
+    collections::VecDeque,
+    fmt,
+    io::{self, Read, Write as _},
+    process::{ChildStderr, ChildStdout},
+};
+
+use futures_lite::{AsyncRead, AsyncReadExt};
+use zng_txt::Txt;
+
+/// Record stdout of a child process while also passing though the output to the running process output.
+///
+/// Both blocking and async APIs are provided, the blocking API is slightly more efficient.
+pub struct StdoutTap(StdTap<false>);
+impl fmt::Debug for StdoutTap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("StdoutTap").finish_non_exhaustive()
+    }
+}
+impl StdoutTap {
+    /// Start recording and passing.
+    pub fn new_blocking(stream: ChildStdout) -> Self {
+        Self(StdTap::new_blocking(stream))
+    }
+
+    /// Start recording and passing.
+    pub fn new(stream: super::ChildStdout) -> Self {
+        Self(StdTap::new(stream))
+    }
+
+    /// Placeholder tap that records nothing.
+    pub fn null() -> Self {
+        Self(StdTap::null())
+    }
+
+    /// Block until the child process closes stdout and converts the capture to string.
+    pub fn into_string_blocking(self) -> String {
+        self.0.into_string_blocking()
+    }
+
+    /// Await until the child process closes stdout and converts the capture to string.
+    pub async fn into_string(self) -> String {
+        blocking::unblock(move || self.into_string_blocking()).await
+    }
+
+    /// Block until the child process closes stdout and converts the capture to [`Txt`].
+    pub fn into_txt_blocking(self) -> Txt {
+        self.0.into_txt_blocking()
+    }
+
+    /// Await until the child process closes stdout and converts the capture to [`Txt`].
+    pub async fn into_txt(self) -> Txt {
+        blocking::unblock(move || self.into_txt_blocking()).await
+    }
+}
+
+/// Record stderr of a child process while also passing though the output to the running process output.
+///
+/// Both blocking and async APIs are provided, the blocking API is slightly more efficient.
+pub struct StderrTap(StdTap<false>);
+impl fmt::Debug for StderrTap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("StderrTap").finish_non_exhaustive()
+    }
+}
+impl StderrTap {
+    /// Start recording and passing.
+    pub fn new_blocking(stream: ChildStderr) -> Self {
+        Self(StdTap::new_blocking(stream))
+    }
+
+    /// Start recording and passing.
+    pub fn new(stream: super::ChildStderr) -> Self {
+        Self(StdTap::new(stream))
+    }
+
+    /// Placeholder tap that records nothing.
+    pub fn null() -> Self {
+        Self(StdTap::null())
+    }
+
+    /// Block until the child process closes stderr and converts the capture to string.
+    pub fn into_string_blocking(self) -> String {
+        self.0.into_string_blocking()
+    }
+
+    /// Await until the child process closes stderr and converts the capture to string.
+    pub async fn into_string(self) -> String {
+        blocking::unblock(move || self.into_string_blocking()).await
+    }
+
+    /// Block until the child process closes stderr and converts the capture to [`Txt`].
+    pub fn into_txt_blocking(self) -> Txt {
+        self.0.into_txt_blocking()
+    }
+
+    /// Await until the child process closes stderr and converts the capture to [`Txt`].
+    pub async fn into_txt(self) -> Txt {
+        blocking::unblock(move || self.into_txt_blocking()).await
+    }
+}
+
+struct StdTap<const E: bool>(Option<std::thread::JoinHandle<VecDeque<u8>>>);
+
+impl<const E: bool> StdTap<E> {
+    fn new_blocking(std_stream: impl Read + Send + 'static) -> Self {
+        Self(Some(tap(std_stream, E)))
+    }
+
+    fn new(stream: impl AsyncRead + Send + Unpin + 'static) -> Self {
+        Self(Some(tap_async(stream, E)))
+    }
+
+    fn null() -> Self {
+        Self(None)
+    }
+
+    fn capture(self) -> VecDeque<u8> {
+        match self.0 {
+            Some(j) => match j.join() {
+                Ok(d) => d,
+                Err(p) => std::panic::resume_unwind(p),
+            },
+            None => VecDeque::new(),
+        }
+    }
+
+    fn into_string_blocking(self) -> String {
+        deque_to_string(self.capture())
+    }
+
+    fn into_txt_blocking(self) -> Txt {
+        self.into_string_blocking().into()
+    }
+}
+
+fn tap(mut stream: impl Read + Send + 'static, is_err: bool) -> std::thread::JoinHandle<VecDeque<u8>> {
+    tap_thread(is_err)
+        .spawn(move || tap_read_loop(&mut stream, is_err))
+        .expect("failed to spawn thread")
+}
+fn tap_thread(is_err: bool) -> std::thread::Builder {
+    std::thread::Builder::new()
+        .name(format!("{}-reader", if is_err { "stderr" } else { "stdout" }))
+        .stack_size(256 * 1024)
+}
+fn tap_read_loop(stream: &mut dyn Read, is_err: bool) -> VecDeque<u8> {
+    let mut tap = Tap::new();
+    loop {
+        let r = stream.read(&mut tap.buffer);
+        if tap.push(r, is_err) {
+            break;
+        }
+    }
+    tap.rec
+}
+
+fn tap_async(mut stream: impl AsyncRead + Send + Unpin + 'static, is_err: bool) -> std::thread::JoinHandle<VecDeque<u8>> {
+    tap_thread(is_err)
+        .spawn(move || tap_async_read_loop(&mut stream, is_err))
+        .expect("failed to spawn thread")
+}
+
+fn tap_async_read_loop(stream: &mut (dyn AsyncRead + Unpin), is_err: bool) -> VecDeque<u8> {
+    let mut tap = Tap::new();
+    loop {
+        let r = crate::block_on(stream.read(&mut tap.buffer));
+        if tap.push(r, is_err) {
+            break;
+        }
+    }
+    tap.rec
+}
+struct Tap {
+    rec: VecDeque<u8>,
+    buffer: [u8; 16_384],
+}
+impl Tap {
+    fn new() -> Self {
+        Self {
+            rec: VecDeque::with_capacity(16_384),
+            buffer: [0; 16_384],
+        }
+    }
+
+    fn push(&mut self, read_r: io::Result<usize>, is_err: bool) -> bool {
+        const MAX_CAPTURE: usize = 8_388_608;
+
+        match read_r {
+            Ok(n) => {
+                if n == 0 {
+                    return true;
+                }
+
+                let new = &self.buffer[..n];
+                let next_len = self.rec.len() + new.len();
+                if next_len > MAX_CAPTURE {
+                    let overflow = self.rec.len() + new.len() - MAX_CAPTURE;
+                    self.rec.drain(..overflow);
+                }
+                self.rec.extend(new);
+
+                let r = if is_err {
+                    let mut s = std::io::stderr();
+                    s.write_all(new).and_then(|_| s.flush())
+                } else {
+                    let mut s = std::io::stdout();
+                    s.write_all(new).and_then(|_| s.flush())
+                };
+                if let Err(e) = r {
+                    panic!("{} write error, {}", if is_err { "stderr" } else { "stdout" }, e)
+                }
+            }
+            Err(e) => panic!("{} read error, {}", if is_err { "stderr" } else { "stdout" }, e),
+        }
+
+        false
+    }
+}
+
+fn deque_to_string(deq: VecDeque<u8>) -> String {
+    let deq: Vec<u8> = deq.into();
+    match String::from_utf8_lossy(&deq) {
+        std::borrow::Cow::Borrowed(_) => {
+            // SAFETY: from_utf8_lossy only returns `Borrowed` when the input is valid utf-8
+            unsafe { String::from_utf8_unchecked(deq) }
+        }
+        std::borrow::Cow::Owned(s) => s,
+    }
+}

--- a/crates/zng-unit/src/byte.rs
+++ b/crates/zng-unit/src/byte.rs
@@ -159,7 +159,7 @@ impl ByteLength {
     /// Length in bytes.
     ///
     /// This is the same as `.0`.
-    pub fn bytes(&self) -> u64 {
+    pub const fn bytes(&self) -> u64 {
         self.0
     }
 

--- a/crates/zng/src/task.rs
+++ b/crates/zng/src/task.rs
@@ -234,7 +234,7 @@ pub mod channel {
     };
 }
 
-#[cfg(ipc)]
+#[cfg(not(wasm))]
 pub use zng_task::process;
 
 pub use zng_app::widget::UiTaskWidget;

--- a/examples/respawn/src/main.rs
+++ b/examples/respawn/src/main.rs
@@ -1,3 +1,5 @@
+#![windows_subsystem = "windows"]
+
 //! Demonstrates app-process crash handler and view-process respawn.
 
 use zng::{


### PR DESCRIPTION
Expose capture code in `zng::task::process::tap`

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->