### PR TITLE
Increase CARGO_NET_RETRY in Github workflows

### DIFF
--- a/.github/workflows/check-features.yml
+++ b/.github/workflows/check-features.yml
@@ -14,6 +14,7 @@ env:
   RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
+  CARGO_NET_RETRY: 10
 
 jobs:
   check-ubuntu:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
   NEXTEST_RETRIES: 3
+  CARGO_NET_RETRY: 10
 
 jobs:
   check-ubuntu:

--- a/.github/workflows/do.yml
+++ b/.github/workflows/do.yml
@@ -19,6 +19,7 @@ env:
   RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
+  CARGO_NET_RETRY: 10
 
 jobs:
   do:

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -10,6 +10,7 @@ env:
   RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings -A unused_assignments'
   RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
+  CARGO_NET_RETRY: 10
 
 jobs:
   check-ubuntu:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ env:
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
   NEXTEST_RETRIES: 3
+  CARGO_NET_RETRY: 10
 
 jobs:
   check-ubuntu:

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -6,6 +6,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
+  CARGO_NET_RETRY: 10
 
 jobs:
   semver-checks:

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -12,6 +12,7 @@ env:
   RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
+  CARGO_NET_RETRY: 10
 
 jobs:
   doc:


### PR DESCRIPTION
Recently getting a lot failed action runs due to cargo network issues

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->