### PR TITLE
Deprecate `yield_until_app`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* **Deprecated** `yield_until_app` in `on_process_start!` args.
 * Fix `ContextMenu!` in `Markdown!` and `AnsiText!` having the parent text font and size.
 * View-process crash respawn now logs panic location and message extracted from stderr.
 * Add `WorkerCrashError::stderr` and helper methods.

--- a/crates/zng-env/src/process.rs
+++ b/crates/zng-env/src/process.rs
@@ -150,6 +150,7 @@ fn process_init_impl(handlers: &[fn(&ProcessStartArgs)]) -> MainExitHandler {
     assert_eq!(process_state, ProcessLifetimeState::BeforeInit, "init!() already called");
 
     let mut yielded = vec![];
+    // TODO(breaking) remove this
     let mut yield_until_app = vec![];
     let mut next_handlers_count = handlers.len();
     for h in handlers {
@@ -290,23 +291,11 @@ impl ProcessStartArgs {
         self.yield_requested.store(Self::YIELD_ONCE, Ordering::Relaxed);
     }
 
-    /// Yields until is running the the app-process.
+    /// Deprecated.
     ///
-    /// Returns `true` if should skip the handler.
-    ///
-    /// ```rust
-    /// # macro_rules! on_process_start { ($($tt:tt)*) => { } }
-    /// on_process_start!(|args| {
-    ///     if args.yield_until_app() {
-    ///         return;
-    ///     }
-    ///
-    ///     println!("Is running in the app-process");
-    /// });
-    /// ```
-    ///
-    /// Note that the handler is still called before the `APP` context starts, you can register a `APP.on_init` handler
-    /// to run in the new app context.
+    /// There is actually no way to know if the process is an app-process until `APP.on_init` runs
+    /// because any process can start an app.
+    #[deprecated = "use `APP.on_init` to register a closure that runs if the process becomes an app process"]
     pub fn yield_until_app(&self) -> bool {
         if self.next_handlers_count > 0 && self.yield_count < Self::MAX_YIELD_COUNT {
             // yield until we are the last handler, this ensures we are running in the app-process

--- a/crates/zng-ext-input/src/focus.rs
+++ b/crates/zng-ext-input/src/focus.rs
@@ -668,11 +668,7 @@ impl FOCUS {
     }
 }
 
-zng_env::on_process_start!(|args| {
-    if args.yield_until_app() {
-        return;
-    }
-
+zng_env::on_process_start!(|_| {
     APP.on_init(hn!(|args| {
         WINDOWS_FOCUS.hook_focus_service(FOCUS.focused());
     }));

--- a/crates/zng-ext-input/src/gesture.rs
+++ b/crates/zng-ext-input/src/gesture.rs
@@ -1188,10 +1188,7 @@ impl CommandShortcutMatchesExt for Command {
     }
 }
 
-on_process_start!(|args| {
-    if args.yield_until_app() {
-        return;
-    }
+on_process_start!(|_| {
     APP.on_init(hn!(|args| {
         if !args.is_minimal {
             // command shortcuts are fully detached from the GESTURES service

--- a/crates/zng-ext-l10n/src/lib.rs
+++ b/crates/zng-ext-l10n/src/lib.rs
@@ -55,12 +55,12 @@ mod usage_recorder;
 /// Localization service.
 pub struct L10N;
 
-on_process_start!(|args: &zng_env::ProcessStartArgs| {
-    if args.yield_until_app() {
-        return;
-    }
+on_process_start!(|_| {
+    APP.on_init(hn!(|args| {
+        if args.is_minimal {
+            return;
+        }
 
-    APP.on_init(hn!(|_| {
         #[cfg(feature = "usage_recorder")]
         usage_recorder::on_init();
 

--- a/crates/zng-ext-single-instance/src/lib.rs
+++ b/crates/zng-ext-single-instance/src/lib.rs
@@ -68,7 +68,7 @@ zng_env::on_process_start!(|args| {
     }
 
     if args.next_handlers_count > 0 && args.yield_count < zng_env::ProcessStartArgs::MAX_YIELD_COUNT {
-        // yield until we are the last handler, this ensures we are running in the app-process, before `yield_until_app` handlers.
+        // yield until we are the last handler, this ensures we are running in the app-process.
         return args.yield_once();
     }
 

--- a/crates/zng-ext-svg/src/lib.rs
+++ b/crates/zng-ext-svg/src/lib.rs
@@ -20,12 +20,12 @@ use zng_txt::{Txt, formatx};
 use zng_unit::{ByteLength, ByteUnits as _, Px, PxDensity2d, PxDensityUnits as _, PxSize};
 use zng_var::const_var;
 
-zng_env::on_process_start!(|args| {
-    if args.yield_until_app() {
-        return;
-    }
+zng_env::on_process_start!(|_| {
+    APP.on_init(hn!(|args| {
+        if args.is_minimal {
+            return;
+        }
 
-    APP.on_init(hn!(|_| {
         tracing::trace!("register SVG extension");
         IMAGES.extend(Box::new(SvgRenderExtension::default()));
     }));

--- a/crates/zng-wgt-material-icons/src/lib.rs
+++ b/crates/zng-wgt-material-icons/src/lib.rs
@@ -27,11 +27,12 @@ mod usage_recorder;
     feature = "embedded",
     any(feature = "outlined", feature = "filled", feature = "rounded", feature = "sharp")
 ))]
-zng_env::on_process_start!(|args| {
-    if args.yield_until_app() {
-        return;
-    }
-    zng_app::APP.on_init(zng_app::hn!(|_| {
+zng_env::on_process_start!(|_| {
+    zng_app::APP.on_init(zng_app::hn!(|args| {
+        if args.is_minimal {
+            return;
+        }
+
         use zng_wgt::{ICONS, IconRequestArgs, prelude::UiNode, wgt_fn};
         use zng_wgt_text::icon::{GlyphIcon, Icon};
 

--- a/crates/zng-wgt-text-input/src/lib.rs
+++ b/crates/zng-wgt-text-input/src/lib.rs
@@ -17,10 +17,7 @@ pub mod selectable;
 mod text_input;
 pub use text_input::*;
 
-zng_env::on_process_start!(|args| {
-    if args.yield_until_app() {
-        return;
-    }
+zng_env::on_process_start!(|_| {
     zng_wgt_menu::MENU_TEXT_INPUT.init_label(menu_label, set_menu_label_style);
 });
 fn menu_label(txt: zng_var::Var<zng_wgt::prelude::Txt>) -> zng_app::widget::node::UiNode {

--- a/crates/zng/src/lib.rs
+++ b/crates/zng/src/lib.rs
@@ -847,11 +847,7 @@ mod __prelude_wgt {
 #[cfg(feature = "svg")]
 extern crate zng_ext_svg as _;
 
-zng_env::on_process_start!(|args| {
-    if args.yield_until_app() {
-        return;
-    }
-
+zng_env::on_process_start!(|_| {
     zng_app::APP.on_init(zng_app::hn!(|args| {
         if !args.is_minimal {
             defaults();


### PR DESCRIPTION
The only way to run code in apps only is by registering an `APP.on_init`. That is because any process can spawn an app, the crash handler dialog process for example is currently now loading all services properly because the services are gated by `yield_until_app`.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->