### PR TITLE
Use default cargo http retries

### DIFF
--- a/.cargo/about.toml
+++ b/.cargo/about.toml
@@ -21,5 +21,4 @@ accepted = [
 
 ignore-build-dependencies = true
 ignore-dev-dependencies = true
-filter-noassertion = true
 private = { ignore = true }

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -14,6 +14,24 @@ ignore = [
     # remove this ignore when all dependencies are fixes
     "RUSTSEC-2024-0436",
 
-    # See https://github.com/zng-ui/zng/pull/885
+    # `bincode` is unmaintained
+    # 
+    # already replaced in project crates
+    # 
+    # bincode v1.3.3
+    # ├── hyphenation v0.8.4
+    # │   └── zng-ext-font v0.15.2
+    # └── zng-webrender v0.68.4
+    #     └── zng-view v0.18.2
+    #
+    # remove this ignore when all dependencies are fixes
     "RUSTSEC-2025-0141",
+
+    # `ttf-parser` is unmaintained
+    # 
+    # ttf-parser v0.25.1
+    # ├── rustybuzz v0.20.1
+    # │   └── zng-ext-font v0.15.2
+    # └── zng-ext-font v0.15.2
+    "RUSTSEC-2026-0192",
 ]

--- a/.github/workflows/check-features.yml
+++ b/.github/workflows/check-features.yml
@@ -14,8 +14,8 @@ env:
   RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
-  CARGO_NET_RETRY: 20
-  CARGO_HTTP_MULTIPLEXING: false
+  # CARGO_NET_RETRY: 20
+  # CARGO_HTTP_MULTIPLEXING: false
 
 jobs:
   check-ubuntu:

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # daily
-env:
-  CARGO_NET_RETRY: 20
-  CARGO_HTTP_MULTIPLEXING: false
+# env:
+  # CARGO_NET_RETRY: 20
+  # CARGO_HTTP_MULTIPLEXING: false
 jobs:
   security_audit:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ env:
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
   NEXTEST_RETRIES: 3
-  CARGO_NET_RETRY: 20
-  CARGO_HTTP_MULTIPLEXING: false
+  # CARGO_NET_RETRY: 20
+  # CARGO_HTTP_MULTIPLEXING: false
 
 jobs:
   check-ubuntu:

--- a/.github/workflows/do.yml
+++ b/.github/workflows/do.yml
@@ -19,8 +19,8 @@ env:
   RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
-  CARGO_NET_RETRY: 20
-  CARGO_HTTP_MULTIPLEXING: false
+  # CARGO_NET_RETRY: 20
+  # CARGO_HTTP_MULTIPLEXING: false
 
 jobs:
   do:

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -10,8 +10,8 @@ env:
   RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings -A unused_assignments'
   RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
-  CARGO_NET_RETRY: 20
-  CARGO_HTTP_MULTIPLEXING: false
+  # CARGO_NET_RETRY: 20
+  # CARGO_HTTP_MULTIPLEXING: false
 
 jobs:
   check-ubuntu:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ env:
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
   NEXTEST_RETRIES: 3
-  CARGO_NET_RETRY: 20
-  CARGO_HTTP_MULTIPLEXING: false
+  # CARGO_NET_RETRY: 20
+  # CARGO_HTTP_MULTIPLEXING: false
 
 jobs:
   check-ubuntu:

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -6,8 +6,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
-  CARGO_NET_RETRY: 20
-  CARGO_HTTP_MULTIPLEXING: false
+  # CARGO_NET_RETRY: 20
+  # CARGO_HTTP_MULTIPLEXING: false
 
 jobs:
   semver-checks:

--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -12,8 +12,8 @@ env:
   RUSTDOCFLAGS: '--deny=warnings -A unused_assignments'
   CARGO_TERM_COLOR: always
   ZNG_TP_LICENSES: false
-  CARGO_NET_RETRY: 20
-  CARGO_HTTP_MULTIPLEXING: false
+  # CARGO_NET_RETRY: 20
+  # CARGO_HTTP_MULTIPLEXING: false
 
 jobs:
   doc:

--- a/crates/zng-task/Cargo.toml
+++ b/crates/zng-task/Cargo.toml
@@ -34,6 +34,7 @@ http = [
 # Enables HTTP cookie storage option.
 http_cookie = [
     "dep:cookie_store",
+    "dep:time",
 ]
 # Enables HTTP compression option.
 http_compression = [
@@ -86,6 +87,8 @@ httparse = { version = "1.10.1", default-features = false, features = ["std"], o
 mime = { version = "0.3", default-features = false, optional = true }
 encoding_rs = { version = "0.8.35", default-features = false, features = ["alloc"], optional = true }
 cookie_store = { version = "0.22.0", default-features = false, features = ["serde"], optional = true }
+# temporary fix for cookies build, a dependency of cookie_store
+time = { version = ">=0.3,<=0.3.51", default-features = false, optional = true }
 flate2 = { version = "1.1.5", default-features = false, features = ["rust_backend"], optional = true }
 async-compression = { version = "0.4.34", default-features = false, features = ["futures-io", "zstd", "brotli", "gzip"], optional = true }
 bytemuck = { version = "1.24.0", default-features = false, features = ["extern_crate_alloc"] }

--- a/crates/zng-view/about.toml
+++ b/crates/zng-view/about.toml
@@ -15,5 +15,4 @@ accepted = [
 
 ignore-build-dependencies = true
 ignore-dev-dependencies = true
-filter-noassertion = true
 private = { ignore = true }

--- a/crates/zng/src/third_party.rs
+++ b/crates/zng/src/third_party.rs
@@ -42,7 +42,6 @@
 //!
 //! ignore-build-dependencies = true
 //! ignore-dev-dependencies = true
-//! filter-noassertion = true
 //! private = { ignore = true }
 //! ```
 //!


### PR DESCRIPTION
Rust 1.96.1 may have fixed the issue.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->