### PR TITLE
Fix `l10n!` args not supporting all `T: Display`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `l10n!` args not supporting all `T: Display`.
 * Add `MergeVarBuilder::build_bidi` and `build_bidi_modify`.
 * Add `zng::var::AnyMergeVarBuilder`.
 

--- a/crates/zng-ext-l10n-proc-macros/src/l10n.rs
+++ b/crates/zng-ext-l10n-proc-macros/src/l10n.rs
@@ -98,7 +98,7 @@ pub fn expand(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             build.extend(quote_spanned! {span=>
                 .l10n_arg(#var, {
                     use #l10n_path::IntoL10nVar;
-                    (&mut &mut #l10n_path::L10nSpecialize(Some(#var_ident))).to_l10n_var()
+                    (&mut &mut &mut #l10n_path::L10nSpecialize(Some(#var_ident))).to_l10n_var()
                 })
             });
         }

--- a/crates/zng-ext-l10n/src/types.rs
+++ b/crates/zng-ext-l10n/src/types.rs
@@ -269,18 +269,22 @@ pub struct L10nSpecialize<T>(pub Option<T>);
 pub trait IntoL10nVar {
     fn to_l10n_var(&mut self) -> Var<L10nArgument>;
 }
-
-impl<T: Into<L10nArgument>> IntoL10nVar for L10nSpecialize<T> {
+impl<T: fmt::Display> IntoL10nVar for L10nSpecialize<T> {
+    fn to_l10n_var(&mut self) -> Var<L10nArgument> {
+        const_var(self.0.take().unwrap().to_txt().into())
+    }
+}
+impl<T: Into<L10nArgument>> IntoL10nVar for &mut L10nSpecialize<T> {
     fn to_l10n_var(&mut self) -> Var<L10nArgument> {
         const_var(self.0.take().unwrap().into())
     }
 }
-impl<T: VarValue + Into<L10nArgument>> IntoL10nVar for &mut L10nSpecialize<Var<T>> {
+impl<T: VarValue + Into<L10nArgument>> IntoL10nVar for &mut &mut L10nSpecialize<Var<T>> {
     fn to_l10n_var(&mut self) -> Var<L10nArgument> {
         self.0.take().unwrap().map_into()
     }
 }
-impl IntoL10nVar for &mut &mut L10nSpecialize<Var<L10nArgument>> {
+impl IntoL10nVar for &mut &mut &mut L10nSpecialize<Var<L10nArgument>> {
     fn to_l10n_var(&mut self) -> Var<L10nArgument> {
         self.0.take().unwrap()
     }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->