### PR TITLE
Upgrade `quick-xml`

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -11,7 +11,7 @@ ignore = [
     #         └── arboard 3.4.1
     #             └── zng-view 0.8.0
     #
-    # remove this ignore when all dependencies are fixes
+    # remove this ignore when all dependencies are fixed
     "RUSTSEC-2024-0436",
 
     # `bincode` is unmaintained
@@ -24,7 +24,7 @@ ignore = [
     # └── zng-webrender v0.68.4
     #     └── zng-view v0.18.2
     #
-    # remove this ignore when all dependencies are fixes
+    # remove this ignore when all dependencies are fixed
     "RUSTSEC-2025-0141",
 
     # `ttf-parser` is unmaintained
@@ -34,4 +34,20 @@ ignore = [
     # │   └── zng-ext-font v0.15.2
     # └── zng-ext-font v0.15.2
     "RUSTSEC-2026-0192",
+
+    # Quadratic run time when checking a start tag for duplicate attribute names
+    #
+    # quick-xml v0.39.4
+    # ├── wayland-scanner v0.31.10 (proc-macro)
+    # │   ├── smithay-client-toolkit v0.19.2
+    # │   │   └── winit v0.30.13
+    # │   │       ├── accesskit_winit v0.33.1
+    # │   │       │   └── zng-view v0.18.3 
+    # │   │       └── zng-view v0.18.3
+    # │   ├── wayland-client v0.31.14
+    # │   │   └── zng-view v0.18.3
+    # 
+    # Remove this ignore when dependencies are fixed
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/crates/cargo-zng/Cargo.toml
+++ b/crates/cargo-zng/Cargo.toml
@@ -44,7 +44,7 @@ anyhow = { version = "1.0", features = ["std"], default-features = false }
 dunce = { version = "1.0", default-features = false }
 zng-env = { path = "../zng-env", version = "0.11.4", default-features = false, features = ["parse"] }
 directories = { version = "6.0", default-features = false }
-quick-xml = { version = "0.40", features = ["serialize"], default-features = false }
+quick-xml = { version = "0.41", features = ["serialize"], default-features = false }
 
 # fmt
 regex = { version = "1.10", features = ["std", "perf", "unicode"], default-features = false }


### PR DESCRIPTION
To fix https://rustsec.org/advisories/RUSTSEC-2026-0194

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->