### PR TITLE
Fix keyboard focus navigation not entering `Scroll!` automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix keyboard focus navigation not entering `Scroll!` automatically.
 * Implement add/sub operations from `u32` for `TabIndex`.
 * Add `TabIndex::FIRST`.
 * Change auto mnemonic key to be selected by tab index order.

--- a/crates/zng-wgt-scroll/src/lib.rs
+++ b/crates/zng-wgt-scroll/src/lib.rs
@@ -81,7 +81,7 @@ impl Scroll {
             clip_to_bounds = true;
             focusable = true;
             focus_scope = true;
-            focus_scope_behavior = FocusScopeOnFocus::LastFocused;
+            focus_scope_behavior = FocusScopeOnFocus::LastFocusedIgnoreBounds;
         }
         self.widget_builder().push_build_action(on_build);
     }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->