### PR TITLE
Add focus highlight indicator for `Scroll!` with no focusable children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Add focus highlight indicator for `Scroll!` with no focusable children.
 * Change `toggle::RadioStyle!`.
     - Align mark to top in multi-line content.
 * Change `toggle::CheckStyle!`.

--- a/crates/zng-wgt-scroll/src/lib.rs
+++ b/crates/zng-wgt-scroll/src/lib.rs
@@ -82,6 +82,15 @@ impl Scroll {
             focusable = true;
             focus_scope = true;
             focus_scope_behavior = FocusScopeOnFocus::LastFocusedIgnoreBounds;
+
+            // in case the scroll has no focusable children
+            when *#zng_wgt_input::focus::is_focused_hgl {
+                zng_wgt_fill::foreground_highlight = {
+                    offsets: zng_wgt_input::focus::FOCUS_HIGHLIGHT_OFFSETS_VAR,
+                    widths: zng_wgt_input::focus::FOCUS_HIGHLIGHT_WIDTHS_VAR,
+                    sides: zng_wgt_input::focus::FOCUS_HIGHLIGHT_SIDES_VAR,
+                };
+            }
         }
         self.widget_builder().push_build_action(on_build);
     }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->