### PR TITLE
Fix `Markdown!` default link handling on Windows

### DIFF
--- a/crates/zng-wgt-markdown/src/resolvers.rs
+++ b/crates/zng-wgt-markdown/src/resolvers.rs
@@ -397,7 +397,7 @@ pub fn try_open_link(args: &LinkArgs) -> bool {
                             {
                                 let p = p.display().to_string();
                                 let p = p.replace('/', "\\");
-                                let r = std::process::Command::new("explorer").arg(format!("/select,\"{p}\"")).spawn();
+                                let r = std::process::Command::new("explorer").arg("/select,").arg(p).spawn();
                                 if let Err(e) = r {
                                     tracing::error!("cannot spawn explorer to reveal path, {e}");
                                     status.set(Status::Err);


### PR DESCRIPTION
Fix handling of paths with space not revealing on Explorer

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->