### PR TITLE
Fix `Markdown!` parser including Fluent bidi markers in URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix `Markdown!` parser including Fluent bidi markers in URIs.
 * Fix measure metrics use not tracking for invalidation.
     - Fixes grid cells width sometimes getting stuck.
 * Fix `Markdown!` default link handling on Windows.

--- a/crates/zng-wgt-markdown/src/lib.rs
+++ b/crates/zng-wgt-markdown/src/lib.rs
@@ -633,6 +633,8 @@ fn markdown_view_fn(md: &str) -> UiNode {
             TagEnd::Link => {
                 let (inlines_start, kind, url, title, _id) = link.take().unwrap();
                 let title = html_escape::decode_html_entities(title.as_ref());
+                // trim bidi markers inserted by Fluent
+                let url = url.as_ref().trim_start_matches('\u{2068}').trim_end_matches('\u{2069}');
                 let url = link_resolver.resolve(url.as_ref());
                 match kind {
                     LinkType::Autolink | LinkType::Email => {

--- a/crates/zng-wgt-markdown/src/resolvers.rs
+++ b/crates/zng-wgt-markdown/src/resolvers.rs
@@ -252,8 +252,11 @@ pub fn try_scroll_link(args: &LinkArgs) -> bool {
     false
 }
 
-/// Try open link, only works if the `url` is a full HTTP(S) URL or a dir/file path,
+/// Try open link, only works if the `url` is a full HTTP(S) URL or a dir/file path that exists,
 /// returns if the confirm tooltip is visible.
+///
+/// The popup will offer "Open in Browser" for HTTP links and "Reveal in File Manager" for file paths. The
+/// popup also offers alternative to copy the full link.
 pub fn try_open_link(args: &LinkArgs) -> bool {
     if args.propagation.is_stopped() {
         return false;


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->