### PR TITLE
Suppress audit unmaintained `rustybuzz`

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,8 +4,8 @@ ignore = [
     #
     # already replaced in project crates, `image` dependency still use it:
     #
-    # ├── rav1e 0.7.1 - already fixed (0.8)
-    # └── ravif 0.11.11 - already updated
+    # ├── rav1e 0.8.1 - already fixed but not released
+    # └── ravif 0.13.0 - already updated
     #     └── image 0.25.5 - pending
     #         ├── zng-view 0.8.0
     #         └── arboard 3.4.1
@@ -27,13 +27,14 @@ ignore = [
     # remove this ignore when all dependencies are fixed
     "RUSTSEC-2025-0141",
 
-    # `ttf-parser` is unmaintained
+    # `ttf-parser` and `rustybuzz` are unmaintained
     # 
     # ttf-parser v0.25.1
     # ├── rustybuzz v0.20.1
     # │   └── zng-ext-font v0.15.2
     # └── zng-ext-font v0.15.2
     "RUSTSEC-2026-0192",
+    "RUSTSEC-2026-0206",
 
     # Quadratic run time when checking a start tag for duplicate attribute names
     #


### PR DESCRIPTION
Will replace with `harfrust` (and ttf-parser with `read-fonts`). Unfortunately those changes are breaking.