### PR TITLE
Replace font loading and shaper crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Replace unmaintained font parsing and shaping dependencies.
+    - **Breaking** Removed `harfbuzz` and `ttf` methods from `FontFace`.
+    - **Breaking** Removed `Font::harfbuzz`.
+    - **Breaking** Removed `FontFaceMetrics` and `FontFace::metrics`.
 
 # 0.23.5
 

--- a/crates/zng-ext-font/Cargo.toml
+++ b/crates/zng-ext-font/Cargo.toml
@@ -41,8 +41,9 @@ zng-ext-image = { path = "../zng-ext-image", version = "0.13.5", default-feature
 
 serde = { version = "1.0", default-features = false }
 unicase = { version = "2.7", default-features = false }
-rustybuzz = { version = "0.20", default-features = false, features = ["std"] }
-ttf-parser = { version = "0.25", default-features = false, features = ["std", "apple-layout", "opentype-layout", "variable-fonts"] }
+harfrust = { version = "0.12", default-features = false, features = ["std"] }
+read-fonts = { version = "0.41", default-features = false, features = ["std"] }
+skrifa = { version = "0.44", default-features = false, features = ["std"] }
 byteorder = { version = "1.5", default-features = false, features = ["std"] }
 icu_properties = { version = "2.0", default-features = false, features = ["compiled_data"] }
 bitflags = { version = "2.5", default-features = false, features = ["serde", "bytemuck"] }

--- a/crates/zng-ext-font/src/emoji_util.rs
+++ b/crates/zng-ext-font/src/emoji_util.rs
@@ -36,10 +36,10 @@ Offset32 = uint32
 // OpenType is Big Endian, table IDs are their ASCII name (4 chars) as an `u32`.
 
 /// Color Palette Table
-const CPAL: u32 = u32::from_be_bytes(*b"CPAL");
+const CPAL: skrifa::Tag = skrifa::Tag::new(b"CPAL");
 
 /// Color Table.
-const COLR: u32 = u32::from_be_bytes(*b"COLR");
+const COLR: skrifa::Tag = skrifa::Tag::new(b"COLR");
 
 /// CPAL table.
 ///
@@ -48,7 +48,7 @@ const COLR: u32 = u32::from_be_bytes(*b"COLR");
 /// [`FontFace::color_palettes`]: crate::FontFace::color_palettes
 #[derive(Clone, Copy)]
 pub struct ColorPalettes<'a> {
-    table: &'a [u8],
+    table: read_fonts::FontData<'a>,
     num_palettes: u16,
     num_palette_entries: u16,
     color_records_array_offset: u32,
@@ -60,7 +60,7 @@ impl ColorPalettes<'static> {
     /// No color palettes.
     pub fn empty() -> Self {
         Self {
-            table: &[],
+            table: read_fonts::FontData::new(&[]),
             num_palettes: 0,
             num_palette_entries: 0,
             color_records_array_offset: 0,
@@ -72,7 +72,7 @@ impl ColorPalettes<'static> {
     /// New from font.
     ///
     /// Palettes are parsed on demand.
-    pub fn new<'a>(font: ttf_parser::RawFace<'a>) -> ColorPalettes<'a> {
+    pub(crate) fn new<'a>(font: read_fonts::FontRef<'a>) -> ColorPalettes<'a> {
         match Self::new_impl(font) {
             Ok(g) => g,
             Err(e) => {
@@ -81,8 +81,8 @@ impl ColorPalettes<'static> {
             }
         }
     }
-    fn new_impl<'a>(font: ttf_parser::RawFace<'a>) -> std::io::Result<ColorPalettes<'a>> {
-        let table = match font.table(ttf_parser::Tag(CPAL)) {
+    fn new_impl<'a>(font: read_fonts::FontRef<'a>) -> std::io::Result<ColorPalettes<'a>> {
+        let table = match font.table_data(CPAL) {
             Some(t) => t,
             None => return Ok(Self::empty()),
         };
@@ -161,7 +161,7 @@ impl<'a> ColorPalettes<'a> {
     }
 
     fn palette_types_iter(&self) -> impl Iterator<Item = ColorPaletteType> + 'a {
-        let mut cursor = std::io::Cursor::new(&self.table[self.palette_types_array_offset as usize..]);
+        let mut cursor = std::io::Cursor::new(&self.table.as_bytes()[self.palette_types_array_offset as usize..]);
         let mut i = if self.palette_types_array_offset > 0 {
             self.num_palettes
         } else {
@@ -202,19 +202,20 @@ impl<'a> ColorPalettes<'a> {
         if self.palette_types_array_offset == 0 || i >= self.num_palettes {
             return ColorPaletteType::empty();
         }
-        let t = &self.table[self.palette_types_array_offset as usize + i as usize * 4..];
+        let t = &self.table.as_ref()[self.palette_types_array_offset as usize + i as usize * 4..];
         let flags = BigEndian::read_u32(t);
         ColorPaletteType::from_bits_retain(flags)
     }
 
     fn palette_get(&self, i: u16) -> Option<ColorPalette<'a>> {
         if i < self.num_palettes {
-            let byte_i = BigEndian::read_u16(&self.table[self.color_record_indices_offset as usize + i as usize * 2..]) as usize * 4;
+            let byte_i =
+                BigEndian::read_u16(&self.table.as_bytes()[self.color_record_indices_offset as usize + i as usize * 2..]) as usize * 4;
 
             let start = self.color_records_array_offset as usize + byte_i;
             let palette_len = self.num_palette_entries as usize * 4;
             Some(ColorPalette {
-                table: &self.table[start..start + palette_len],
+                table: &self.table.as_bytes()[start..start + palette_len],
                 flags: self.index_palette_type(i),
             })
         } else {
@@ -291,7 +292,7 @@ impl<'a> ColorPalette<'a> {
 /// [`FontFace::color_glyphs`]: crate::FontFace::color_glyphs
 #[derive(Clone, Copy)]
 pub struct ColorGlyphs<'a> {
-    table: &'a [u8],
+    table: read_fonts::FontData<'a>,
     num_base_glyph_records: u16,
     base_glyph_records_offset: u32,
     layer_records_offset: u32,
@@ -300,7 +301,7 @@ impl ColorGlyphs<'static> {
     /// No color glyphs.
     pub fn empty() -> Self {
         Self {
-            table: &[],
+            table: read_fonts::FontData::new(&[]),
             num_base_glyph_records: 0,
             base_glyph_records_offset: 0,
             layer_records_offset: 0,
@@ -310,7 +311,7 @@ impl ColorGlyphs<'static> {
     /// New from font.
     ///
     /// Color glyphs are parsed on demand.
-    pub fn new<'a>(font: ttf_parser::RawFace<'a>) -> ColorGlyphs<'a> {
+    pub(crate) fn new<'a>(font: read_fonts::FontRef<'a>) -> ColorGlyphs<'a> {
         match Self::new_impl(font) {
             Ok(g) => g,
             Err(e) => {
@@ -319,8 +320,8 @@ impl ColorGlyphs<'static> {
             }
         }
     }
-    fn new_impl<'a>(font: ttf_parser::RawFace<'a>) -> std::io::Result<ColorGlyphs<'a>> {
-        let table = match font.table(ttf_parser::Tag(COLR)) {
+    fn new_impl<'a>(font: read_fonts::FontRef<'a>) -> std::io::Result<ColorGlyphs<'a>> {
+        let table = match font.table_data(COLR) {
             Some(t) => t,
             None => return Ok(Self::empty()),
         };
@@ -379,7 +380,7 @@ impl<'a> ColorGlyphs<'a> {
         let (first_layer_index, num_layers) = self.find_base_glyph(base_glyph)?;
 
         let record_size = 4;
-        let table = &self.table[self.layer_records_offset as usize + (first_layer_index as usize * record_size)..];
+        let table = &self.table.as_bytes()[self.layer_records_offset as usize + (first_layer_index as usize * record_size)..];
         Some(ColorGlyph { table, num_layers })
     }
 
@@ -413,11 +414,11 @@ impl<'a> ColorGlyphs<'a> {
                 return None;
             }
 
-            let glyph_id = BigEndian::read_u16(&self.table[pos..pos + 2]);
+            let glyph_id = BigEndian::read_u16(&self.table.as_ref()[pos..pos + 2]);
             match glyph_id.cmp(&base_glyph) {
                 std::cmp::Ordering::Equal => {
-                    let first_layer_index = BigEndian::read_u16(&self.table[pos + 2..pos + 4]);
-                    let num_layers = BigEndian::read_u16(&self.table[pos + 4..pos + 6]);
+                    let first_layer_index = BigEndian::read_u16(&self.table.as_ref()[pos + 2..pos + 4]);
+                    let num_layers = BigEndian::read_u16(&self.table.as_ref()[pos + 4..pos + 6]);
                     return if num_layers > 0 {
                         Some((first_layer_index, num_layers))
                     } else {

--- a/crates/zng-ext-font/src/font_features.rs
+++ b/crates/zng-ext-font/src/font_features.rs
@@ -31,9 +31,9 @@ impl From<&'static [u8; 4]> for FontFeatureName {
         FontFeatureName(*name)
     }
 }
-impl From<FontFeatureName> for ttf_parser::Tag {
+impl From<FontFeatureName> for skrifa::Tag {
     fn from(value: FontFeatureName) -> Self {
-        ttf_parser::Tag::from_bytes(&value.0)
+        skrifa::Tag::new(&value.0)
     }
 }
 impl ops::Deref for FontFeatureName {
@@ -153,7 +153,7 @@ impl FontFeatures {
     pub fn finalize(&self) -> RFontFeatures {
         self.0
             .iter()
-            .map(|(&n, &s)| rustybuzz::Feature::new(ttf_parser::Tag::from(n), s, 0..usize::MAX))
+            .map(|(&n, &s)| harfrust::Feature::new(skrifa::Tag::from(n), s, 0..usize::MAX))
             .collect()
     }
 }
@@ -169,8 +169,8 @@ impl fmt::Debug for FontFeatures {
 
 /// Finalized [`FontFeatures`].
 ///
-/// This is a vec of [harfbuzz features](https://docs.rs/rustybuzz/0.17.0/rustybuzz/struct.Feature.html).
-pub type RFontFeatures = Vec<rustybuzz::Feature>;
+/// This is a vec of [harfbuzz features](https://docs.rs/harfrust/latest/harfrust/struct.Feature.html).
+pub type RFontFeatures = Vec<harfrust::Feature>;
 
 /// A builder for [`FontFeatures`].
 ///
@@ -1711,9 +1711,9 @@ impl From<&'static [u8; 4]> for FontVariationName {
         FontVariationName(*name)
     }
 }
-impl From<FontVariationName> for ttf_parser::Tag {
+impl From<FontVariationName> for skrifa::Tag {
     fn from(value: FontVariationName) -> Self {
-        ttf_parser::Tag::from_bytes(&value.0)
+        skrifa::Tag::new(&value.0)
     }
 }
 impl ops::Deref for FontVariationName {
@@ -1813,7 +1813,7 @@ impl FontVariations {
     pub fn finalize(&self) -> RFontVariations {
         self.0
             .iter()
-            .map(|(name, value)| rustybuzz::Variation {
+            .map(|(name, value)| harfrust::Variation {
                 tag: (*name).into(),
                 value: *value,
             })
@@ -1872,4 +1872,4 @@ use zng_var::impl_from_and_into_var;
 /// Finalized [`FontVariations`].
 ///
 /// This is a vec of [harfbuzz variations](https://docs.rs/rustybuzz/0.17.0/rustybuzz/struct.Variation.html).
-pub type RFontVariations = Vec<rustybuzz::Variation>;
+pub type RFontVariations = Vec<harfrust::Variation>;

--- a/crates/zng-ext-font/src/lib.rs
+++ b/crates/zng-ext-font/src/lib.rs
@@ -27,6 +27,7 @@
 
 use font_features::RFontVariations;
 use hashbrown::{HashMap, HashSet};
+use skrifa::MetadataProvider;
 use std::{borrow::Cow, fmt, io, ops, path::PathBuf, slice::SliceIndex, sync::Arc};
 #[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
 use zng_task::channel::WeakIpcBytes;
@@ -72,12 +73,12 @@ use zng_app::{
 use zng_app_context::app_local;
 use zng_ext_l10n::{Lang, LangMap, lang};
 use zng_layout::unit::{
-    ByteUnits as _, EQ_GRANULARITY, EQ_GRANULARITY_100, Factor, FactorPercent, Px, PxPoint, PxRect, PxSize, TimeUnits as _, about_eq,
-    about_eq_hash, about_eq_ord, euclid,
+    ByteUnits as _, EQ_GRANULARITY, EQ_GRANULARITY_100, Factor, FactorPercent, Px, PxRect, TimeUnits as _, about_eq, about_eq_hash,
+    about_eq_ord, euclid,
 };
 use zng_task::parking_lot::{Mutex, RwLock};
 use zng_task::{self as task, channel::IpcBytes};
-use zng_txt::Txt;
+use zng_txt::{ToTxt, Txt};
 use zng_var::{IntoVar, ResponseVar, Var, animation::Transitionable, const_var, impl_from_and_into_var, response_done_var, response_var};
 use zng_view_api::{config::FontAntiAliasing, font::IpcFontBytes};
 
@@ -261,6 +262,9 @@ impl_from_and_into_var! {
     }
     fn from(f: FontName) -> Txt {
         f.into_text()
+    }
+    fn from(s: Txt) -> FontName {
+        FontName::new(s)
     }
 }
 impl fmt::Display for FontName {
@@ -744,35 +748,11 @@ impl FONTS {
     }
 }
 
-impl<'a> From<ttf_parser::Face<'a>> for FontFaceMetrics {
-    fn from(f: ttf_parser::Face<'a>) -> Self {
-        let underline = f
-            .underline_metrics()
-            .unwrap_or(ttf_parser::LineMetrics { position: 0, thickness: 0 });
-        FontFaceMetrics {
-            units_per_em: f.units_per_em() as _,
-            ascent: f.ascender() as f32,
-            descent: f.descender() as f32,
-            line_gap: f.line_gap() as f32,
-            underline_position: underline.position as f32,
-            underline_thickness: underline.thickness as f32,
-            cap_height: f.capital_height().unwrap_or(0) as f32,
-            x_height: f.x_height().unwrap_or(0) as f32,
-            bounds: euclid::rect(
-                f.global_bounding_box().x_min as f32,
-                f.global_bounding_box().x_max as f32,
-                f.global_bounding_box().width() as f32,
-                f.global_bounding_box().height() as f32,
-            ),
-        }
-    }
-}
-
 #[derive(PartialEq, Eq, Hash)]
-struct FontInstanceKey(Px, Box<[(ttf_parser::Tag, i32)]>);
+struct FontInstanceKey(Px, Box<[(skrifa::Tag, i32)]>);
 impl FontInstanceKey {
     /// Returns the key.
-    pub fn new(size: Px, variations: &[rustybuzz::Variation]) -> Self {
+    pub(crate) fn new(size: Px, variations: &[harfrust::Variation]) -> Self {
         let variations_key: Vec<_> = variations.iter().map(|p| (p.tag, (p.value * 1000.0) as i32)).collect();
         FontInstanceKey(size, variations_key.into_boxed_slice())
     }
@@ -795,7 +775,6 @@ struct LoadedFontFace {
     style: FontStyle,
     weight: FontWeight,
     stretch: FontStretch,
-    metrics: FontFaceMetrics,
     lig_carets: LigatureCaretList,
     flags: FontFaceFlags,
     m: Mutex<FontFaceMut>,
@@ -826,7 +805,6 @@ impl fmt::Debug for FontFace {
             .field("style", &self.0.style)
             .field("weight", &self.0.weight)
             .field("stretch", &self.0.stretch)
-            .field("metrics", &self.0.metrics)
             .field("instances.len()", &m.instances.len())
             .field("render_keys.len()", &m.render_ids.len())
             .field("unregistered", &m.unregistered)
@@ -852,19 +830,6 @@ impl FontFace {
             style: FontStyle::Normal,
             weight: FontWeight::NORMAL,
             stretch: FontStretch::NORMAL,
-            // values copied from a monospace font
-            metrics: FontFaceMetrics {
-                units_per_em: 2048,
-                ascent: 1616.0,
-                descent: -432.0,
-                line_gap: 0.0,
-                underline_position: -205.0,
-                underline_thickness: 102.0,
-                cap_height: 1616.0,
-                x_height: 1616.0,
-                // `xMin`/`xMax`/`yMin`/`yMax`
-                bounds: euclid::Box2D::new(euclid::point2(0.0, -432.0), euclid::point2(1291.0, 1616.0)).to_rect(),
-            },
             lig_carets: LigatureCaretList::empty(),
             m: Mutex::new(FontFaceMut {
                 instances: HashMap::default(),
@@ -907,7 +872,6 @@ impl FontFace {
                         style: other_font.0.style,
                         weight: other_font.0.weight,
                         stretch: other_font.0.stretch,
-                        metrics: other_font.0.metrics.clone(),
                         m: Mutex::new(FontFaceMut {
                             instances: Default::default(),
                             render_ids: Default::default(),
@@ -921,40 +885,41 @@ impl FontFace {
             }
         }
 
-        let ttf_face = match ttf_parser::Face::parse(&bytes, face_index) {
+        let ttf_face = match skrifa::FontRef::from_index(&bytes, face_index) {
             Ok(f) => f,
             Err(e) => {
                 match e {
                     // try again with font 0 (font-kit selects a high index for Ubuntu Font)
-                    ttf_parser::FaceParsingError::FaceIndexOutOfBounds => face_index = 0,
+                    read_fonts::ReadError::InvalidCollectionIndex(_) if face_index != 0 => face_index = 0,
                     e => return Err(FontLoadingError::Parse(e)),
                 }
 
-                match ttf_parser::Face::parse(&bytes, face_index) {
+                match skrifa::FontRef::from_index(&bytes, face_index) {
                     Ok(f) => f,
                     Err(_) => return Err(FontLoadingError::Parse(e)),
                 }
             }
         };
+        use read_fonts::TableProvider as _;
 
-        let has_ligatures = ttf_face.tables().gsub.is_some();
+        let has_ligatures = ttf_face.gsub().is_ok();
         let lig_carets = if has_ligatures {
             LigatureCaretList::empty()
         } else {
-            LigatureCaretList::load(ttf_face.raw_face())?
-        };
-
-        // all tables used by `ttf_parser::Face::glyph_raster_image`
-        let has_raster_images = {
-            let t = ttf_face.tables();
-            t.sbix.is_some() || t.bdat.is_some() || t.ebdt.is_some() || t.cbdt.is_some()
+            LigatureCaretList::load(&ttf_face)?
         };
 
         let mut flags = FontFaceFlags::empty();
-        flags.set(FontFaceFlags::IS_MONOSPACE, ttf_face.is_monospaced());
+        flags.set(
+            FontFaceFlags::IS_MONOSPACE,
+            ttf_face.post().map(|p| p.is_fixed_pitch() != 0).unwrap_or(false),
+        );
         flags.set(FontFaceFlags::HAS_LIGATURES, has_ligatures);
-        flags.set(FontFaceFlags::HAS_RASTER_IMAGES, has_raster_images);
-        flags.set(FontFaceFlags::HAS_SVG_IMAGES, ttf_face.tables().svg.is_some());
+        flags.set(
+            FontFaceFlags::HAS_RASTER_IMAGES,
+            ttf_face.sbix().is_ok() || ttf_face.ebdt().is_ok() || ttf_face.cbdt().is_ok(),
+        );
+        flags.set(FontFaceFlags::HAS_SVG_IMAGES, ttf_face.svg().is_ok());
 
         Ok(FontFace(Arc::new(LoadedFontFace {
             face_index,
@@ -964,7 +929,6 @@ impl FontFace {
             style: custom_font.style,
             weight: custom_font.weight,
             stretch: custom_font.stretch,
-            metrics: ttf_face.into(),
             lig_carets,
             m: Mutex::new(FontFaceMut {
                 instances: Default::default(),
@@ -979,88 +943,89 @@ impl FontFace {
     fn load(bytes: FontBytes, mut face_index: u32) -> Result<Self, FontLoadingError> {
         let _span = tracing::trace_span!("FontFace::load").entered();
 
-        let ttf_face = match ttf_parser::Face::parse(&bytes, face_index) {
+        let ttf_face = match skrifa::FontRef::from_index(&bytes, face_index) {
             Ok(f) => f,
             Err(e) => {
                 match e {
                     // try again with font 0 (font-kit selects a high index for Ubuntu Font)
-                    ttf_parser::FaceParsingError::FaceIndexOutOfBounds => face_index = 0,
+                    read_fonts::ReadError::InvalidCollectionIndex(_) if face_index != 0 => face_index = 0,
                     e => return Err(FontLoadingError::Parse(e)),
                 }
 
-                match ttf_parser::Face::parse(&bytes, face_index) {
+                match skrifa::FontRef::from_index(&bytes, face_index) {
                     Ok(f) => f,
                     Err(_) => return Err(FontLoadingError::Parse(e)),
                 }
             }
         };
+        use read_fonts::TableProvider as _;
 
-        let has_ligatures = ttf_face.tables().gsub.is_some();
+        let has_ligatures = ttf_face.gsub().is_ok();
         let lig_carets = if has_ligatures {
             LigatureCaretList::empty()
         } else {
-            LigatureCaretList::load(ttf_face.raw_face())?
+            LigatureCaretList::load(&ttf_face)?
         };
 
         let mut display_name = None;
         let mut family_name = None;
         let mut postscript_name = None;
-        let mut any_name = None::<String>;
-        for name in ttf_face.names() {
-            if let Some(n) = name.to_string() {
-                match name.name_id {
-                    ttf_parser::name_id::FULL_NAME => display_name = Some(n),
-                    ttf_parser::name_id::FAMILY => family_name = Some(n),
-                    ttf_parser::name_id::POST_SCRIPT_NAME => postscript_name = Some(n),
-                    _ => match &mut any_name {
-                        Some(s) => {
-                            if n.len() > s.len() {
-                                *s = n;
+        let mut any_name = None::<Txt>;
+        if let Ok(name) = ttf_face.name() {
+            for record in name.name_record() {
+                let n = match record.string(name.string_data()) {
+                    Ok(n) => n.to_txt(),
+                    Err(_) => continue,
+                };
+                match record.name_id() {
+                    read_fonts::tables::name::NameId::FULL_NAME => display_name = Some(n),
+                    read_fonts::tables::name::NameId::FAMILY_NAME => family_name = Some(n),
+                    read_fonts::tables::name::NameId::POSTSCRIPT_NAME => postscript_name = Some(n),
+                    _ => {
+                        if let Some(t) = &mut any_name {
+                            if t.len() < n.len() {
+                                *t = n;
                             }
+                        } else {
+                            any_name = Some(n)
                         }
-                        None => any_name = Some(n),
-                    },
+                    }
                 }
             }
         }
-        let display_name = FontName::new(Txt::from_str(
+        let display_name = FontName::new(
             display_name
-                .as_ref()
-                .or(family_name.as_ref())
-                .or(postscript_name.as_ref())
-                .or(any_name.as_ref())
-                .unwrap(),
-        ));
+                .clone()
+                .or_else(|| family_name.clone())
+                .or_else(|| postscript_name.clone())
+                .or_else(|| any_name.clone())
+                .unwrap_or_default(),
+        );
         let family_name = family_name.map(FontName::from).unwrap_or_else(|| display_name.clone());
-        let postscript_name = postscript_name.map(Txt::from);
-
-        if ttf_face.units_per_em() == 0 {
-            // observed this in Noto Color Emoji (with font_kit)
-            tracing::debug!("font {display_name:?} units_per_em 0");
-            return Err(FontLoadingError::UnknownFormat);
-        }
-
-        // all tables used by `ttf_parser::Face::glyph_raster_image`
-        let has_raster_images = {
-            let t = ttf_face.tables();
-            t.sbix.is_some() || t.bdat.is_some() || t.ebdt.is_some() || t.cbdt.is_some()
-        };
+        let postscript_name = postscript_name;
 
         let mut flags = FontFaceFlags::empty();
-        flags.set(FontFaceFlags::IS_MONOSPACE, ttf_face.is_monospaced());
+        flags.set(
+            FontFaceFlags::IS_MONOSPACE,
+            ttf_face.post().map(|p| p.is_fixed_pitch() != 0).unwrap_or(false),
+        );
         flags.set(FontFaceFlags::HAS_LIGATURES, has_ligatures);
-        flags.set(FontFaceFlags::HAS_RASTER_IMAGES, has_raster_images);
-        flags.set(FontFaceFlags::HAS_SVG_IMAGES, ttf_face.tables().svg.is_some());
+        flags.set(
+            FontFaceFlags::HAS_RASTER_IMAGES,
+            ttf_face.sbix().is_ok() || ttf_face.ebdt().is_ok() || ttf_face.cbdt().is_ok(),
+        );
+        flags.set(FontFaceFlags::HAS_SVG_IMAGES, ttf_face.svg().is_ok());
+
+        let attr = ttf_face.attributes();
 
         Ok(FontFace(Arc::new(LoadedFontFace {
             face_index,
             family_name,
             display_name,
             postscript_name,
-            style: ttf_face.style().into(),
-            weight: ttf_face.weight().into(),
-            stretch: ttf_face.width().into(),
-            metrics: ttf_face.into(),
+            style: attr.style.into(),
+            weight: attr.weight.into(),
+            stretch: attr.stretch.into(),
             lig_carets,
             m: Mutex::new(FontFaceMut {
                 instances: Default::default(),
@@ -1107,35 +1072,11 @@ impl FontFace {
         key
     }
 
-    /// Loads the harfbuzz face.
-    ///
-    /// Loads from in memory [`bytes`].
-    ///
-    /// Returns `None` if [`is_empty`].
-    ///
-    /// [`is_empty`]: Self::is_empty
-    /// [`bytes`]: Self::bytes
-    pub fn harfbuzz(&self) -> Option<rustybuzz::Face<'_>> {
+    pub(crate) fn raw(&self) -> Option<harfrust::FontRef<'_>> {
         if self.is_empty() {
             None
         } else {
-            Some(rustybuzz::Face::from_slice(&self.0.data, self.0.face_index).unwrap())
-        }
-    }
-
-    /// Loads the full TTF face.
-    ///
-    /// Loads from in memory [`bytes`].
-    ///
-    /// Returns `None` if [`is_empty`].
-    ///
-    /// [`is_empty`]: Self::is_empty
-    /// [`bytes`]: Self::bytes
-    pub fn ttf(&self) -> Option<ttf_parser::Face<'_>> {
-        if self.is_empty() {
-            None
-        } else {
-            Some(ttf_parser::Face::parse(&self.0.data, self.0.face_index).unwrap())
+            Some(harfrust::FontRef::from_index(&self.0.data, self.0.face_index).unwrap())
         }
     }
 
@@ -1181,11 +1122,6 @@ impl FontFace {
     /// Font is monospace (fixed-width).
     pub fn is_monospace(&self) -> bool {
         self.0.flags.contains(FontFaceFlags::IS_MONOSPACE)
-    }
-
-    /// Font metrics in font units.
-    pub fn metrics(&self) -> &FontFaceMetrics {
-        &self.0.metrics
     }
 
     /// Gets a cached sized [`Font`].
@@ -1238,8 +1174,8 @@ impl FontFace {
     ///
     /// Is empty if not provided by the font.
     pub fn color_palettes(&self) -> ColorPalettes<'_> {
-        match self.ttf() {
-            Some(ttf) => ColorPalettes::new(*ttf.raw_face()),
+        match self.raw() {
+            Some(ttf) => ColorPalettes::new(ttf),
             None => ColorPalettes::empty(),
         }
     }
@@ -1248,8 +1184,8 @@ impl FontFace {
     ///
     /// Is empty if not provided by the font.
     pub fn color_glyphs(&self) -> ColorGlyphs<'_> {
-        match self.ttf() {
-            Some(ttf) => ColorGlyphs::new(*ttf.raw_face()),
+        match self.raw() {
+            Some(ttf) => ColorGlyphs::new(ttf),
             None => ColorGlyphs::empty(),
         }
     }
@@ -1293,6 +1229,7 @@ struct LoadedFont {
     render_keys: Mutex<Vec<RenderFont>>,
     small_word_cache: RwLock<HashMap<WordCacheKey<[u8; Font::SMALL_WORD_LEN]>, ShapedSegmentData>>,
     word_cache: RwLock<HashMap<WordCacheKey<String>, ShapedSegmentData>>,
+    shaper_cache: Option<harfrust::ShaperData>,
 }
 impl fmt::Debug for Font {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1326,14 +1263,20 @@ impl Font {
     }
 
     fn new(face: FontFace, size: Px, variations: RFontVariations) -> Self {
+        let (metrics, shaper_cache) = match face.raw() {
+            Some(f) => (FontMetrics::new(&f, size), Some(harfrust::ShaperData::new(&f))),
+            None => (FontMetrics::empty(), None),
+        };
+
         Font(Arc::new(LoadedFont {
-            metrics: face.metrics().sized(size),
+            metrics,
             face,
             size,
             variations,
             render_keys: Mutex::new(vec![]),
             small_word_cache: RwLock::default(),
             word_cache: RwLock::default(),
+            shaper_cache,
         }))
     }
 
@@ -1352,7 +1295,7 @@ impl Font {
         let mut opt = zng_view_api::font::FontOptions::default();
         opt.synthetic_oblique = synthesis.contains(FontSynthesis::OBLIQUE);
         opt.synthetic_bold = synthesis.contains(FontSynthesis::BOLD);
-        let variations = self.0.variations.iter().map(|v| (v.tag.to_bytes(), v.value)).collect();
+        let variations = self.0.variations.iter().map(|v| (v.tag.to_be_bytes(), v.value)).collect();
 
         let key = match renderer.add_font(font_key, self.0.size, opt, variations) {
             Ok(k) => k,
@@ -1370,18 +1313,6 @@ impl Font {
     /// Reference the font face source of this font.
     pub fn face(&self) -> &FontFace {
         &self.0.face
-    }
-
-    /// Gets the sized harfbuzz font.
-    pub fn harfbuzz(&self) -> Option<rustybuzz::Face<'_>> {
-        let ppem = self.0.size.0 as u16;
-
-        let mut font = self.0.face.harfbuzz()?;
-
-        font.set_pixels_per_em(Some((ppem, ppem)));
-        font.set_variations(&self.0.variations);
-
-        Some(font)
     }
 
     /// Font size.
@@ -1410,14 +1341,13 @@ impl Font {
         &self,
         lig: zng_view_api::font::GlyphIndex,
     ) -> impl ExactSizeIterator<Item = f32> + DoubleEndedIterator + '_ {
-        let face = &self.0.face.0;
-        face.lig_carets.carets(lig).iter().map(move |&o| match o {
+        self.0.face.0.lig_carets.carets(lig).iter().map(move |&o| match o {
             ligature_util::LigatureCaret::Coordinate(o) => {
-                let size_scale = 1.0 / face.metrics.units_per_em as f32 * self.0.size.0 as f32;
+                let size_scale = 1.0 / self.0.metrics.units_per_em as f32 * self.0.size.0 as f32;
                 o as f32 * size_scale
             }
             ligature_util::LigatureCaret::GlyphContourPoint(i) => {
-                if let Some(f) = self.harfbuzz() {
+                if let Some(f) = self.face().raw() {
                     struct Search {
                         i: u16,
                         s: u16,
@@ -1431,7 +1361,7 @@ impl Font {
                             }
                         }
                     }
-                    impl ttf_parser::OutlineBuilder for Search {
+                    impl skrifa::outline::OutlinePen for Search {
                         fn move_to(&mut self, x: f32, _y: f32) {
                             self.check(x);
                         }
@@ -1451,8 +1381,18 @@ impl Font {
                         fn close(&mut self) {}
                     }
                     let mut search = Search { i, s: 0, x: 0.0 };
-                    if f.outline_glyph(ttf_parser::GlyphId(lig as _), &mut search).is_some() && search.s >= search.i {
-                        return search.x * self.0.metrics.size_scale;
+                    if let Some(o) = f.outline_glyphs().get(skrifa::GlyphId::new(lig))
+                        && o.draw(
+                            skrifa::outline::DrawSettings::unhinted(
+                                skrifa::instance::Size::new(self.size().0 as f32),
+                                skrifa::instance::LocationRef::default(),
+                            ),
+                            &mut search,
+                        )
+                        .is_ok()
+                        && search.s >= search.i
+                    {
+                        return search.x;
                     }
                 }
                 0.0
@@ -3148,43 +3088,14 @@ impl_from_and_into_var! {
         FontStretch(fct)
     }
 }
-impl From<ttf_parser::Width> for FontStretch {
-    fn from(value: ttf_parser::Width) -> Self {
-        use ttf_parser::Width::*;
-        match value {
-            UltraCondensed => FontStretch::ULTRA_CONDENSED,
-            ExtraCondensed => FontStretch::EXTRA_CONDENSED,
-            Condensed => FontStretch::CONDENSED,
-            SemiCondensed => FontStretch::SEMI_CONDENSED,
-            Normal => FontStretch::NORMAL,
-            SemiExpanded => FontStretch::SEMI_EXPANDED,
-            Expanded => FontStretch::EXPANDED,
-            ExtraExpanded => FontStretch::EXTRA_EXPANDED,
-            UltraExpanded => FontStretch::ULTRA_EXPANDED,
-        }
+impl From<skrifa::attribute::Stretch> for FontStretch {
+    fn from(value: skrifa::attribute::Stretch) -> Self {
+        FontStretch(value.ratio())
     }
 }
-impl From<FontStretch> for ttf_parser::Width {
+impl From<FontStretch> for skrifa::attribute::Stretch {
     fn from(value: FontStretch) -> Self {
-        if value <= FontStretch::ULTRA_CONDENSED {
-            ttf_parser::Width::UltraCondensed
-        } else if value <= FontStretch::EXTRA_CONDENSED {
-            ttf_parser::Width::ExtraCondensed
-        } else if value <= FontStretch::CONDENSED {
-            ttf_parser::Width::Condensed
-        } else if value <= FontStretch::SEMI_CONDENSED {
-            ttf_parser::Width::SemiCondensed
-        } else if value <= FontStretch::NORMAL {
-            ttf_parser::Width::Normal
-        } else if value <= FontStretch::SEMI_EXPANDED {
-            ttf_parser::Width::SemiExpanded
-        } else if value <= FontStretch::EXPANDED {
-            ttf_parser::Width::Expanded
-        } else if value <= FontStretch::EXTRA_EXPANDED {
-            ttf_parser::Width::ExtraExpanded
-        } else {
-            ttf_parser::Width::UltraExpanded
-        }
+        skrifa::attribute::Stretch::new(value.0)
     }
 }
 
@@ -3211,23 +3122,23 @@ impl fmt::Debug for FontStyle {
         }
     }
 }
-impl From<ttf_parser::Style> for FontStyle {
-    fn from(value: ttf_parser::Style) -> Self {
-        use ttf_parser::Style::*;
+impl From<skrifa::attribute::Style> for FontStyle {
+    fn from(value: skrifa::attribute::Style) -> Self {
+        use skrifa::attribute::Style::*;
         match value {
             Normal => FontStyle::Normal,
             Italic => FontStyle::Italic,
-            Oblique => FontStyle::Oblique,
+            Oblique(_) => FontStyle::Oblique,
         }
     }
 }
 
-impl From<FontStyle> for ttf_parser::Style {
+impl From<FontStyle> for skrifa::attribute::Style {
     fn from(value: FontStyle) -> Self {
         match value {
             FontStyle::Normal => Self::Normal,
             FontStyle::Italic => Self::Italic,
-            FontStyle::Oblique => Self::Oblique,
+            FontStyle::Oblique => Self::Oblique(None),
         }
     }
 }
@@ -3326,26 +3237,14 @@ impl_from_and_into_var! {
         FontWeight(weight)
     }
 }
-impl From<ttf_parser::Weight> for FontWeight {
-    fn from(value: ttf_parser::Weight) -> Self {
-        use ttf_parser::Weight::*;
-        match value {
-            Thin => FontWeight::THIN,
-            ExtraLight => FontWeight::EXTRA_LIGHT,
-            Light => FontWeight::LIGHT,
-            Normal => FontWeight::NORMAL,
-            Medium => FontWeight::MEDIUM,
-            SemiBold => FontWeight::SEMIBOLD,
-            Bold => FontWeight::BOLD,
-            ExtraBold => FontWeight::EXTRA_BOLD,
-            Black => FontWeight::BLACK,
-            Other(o) => FontWeight(o as f32),
-        }
+impl From<skrifa::attribute::Weight> for FontWeight {
+    fn from(value: skrifa::attribute::Weight) -> Self {
+        FontWeight(value.value())
     }
 }
-impl From<FontWeight> for ttf_parser::Weight {
+impl From<FontWeight> for skrifa::attribute::Weight {
     fn from(value: FontWeight) -> Self {
-        ttf_parser::Weight::from(value.0 as u16)
+        skrifa::attribute::Weight::new(value.0)
     }
 }
 
@@ -3517,87 +3416,10 @@ impl fmt::Debug for Justify {
     }
 }
 
-/// Various metrics that apply to the entire [`FontFace`].
-///
-/// For OpenType fonts, these mostly come from the `OS/2` table.
-///
-/// See the [`FreeType Glyph Metrics`] documentation for an explanation of the various metrics.
-///
-/// [`FreeType Glyph Metrics`]: https://freetype.org/freetype2/docs/glyphs/glyphs-3.html
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-#[non_exhaustive]
-pub struct FontFaceMetrics {
-    /// The number of font units per em.
-    ///
-    /// Font sizes are usually expressed in pixels per em; e.g. `12px` means 12 pixels per em.
-    pub units_per_em: u32,
-
-    /// The maximum amount the font rises above the baseline, in font units.
-    pub ascent: f32,
-
-    /// The maximum amount the font descends below the baseline, in font units.
-    ///
-    /// This is typically a negative value to match the definition of `sTypoDescender` in the
-    /// `OS/2` table in the OpenType specification. If you are used to using Windows or Mac APIs,
-    /// beware, as the sign is reversed from what those APIs return.
-    pub descent: f32,
-
-    /// Distance between baselines, in font units.
-    pub line_gap: f32,
-
-    /// The suggested distance of the top of the underline from the baseline (negative values
-    /// indicate below baseline), in font units.
-    pub underline_position: f32,
-
-    /// A suggested value for the underline thickness, in font units.
-    pub underline_thickness: f32,
-
-    /// The approximate amount that uppercase letters rise above the baseline, in font units.
-    pub cap_height: f32,
-
-    /// The approximate amount that non-ascending lowercase letters rise above the baseline, in
-    /// font units.
-    pub x_height: f32,
-
-    /// A rectangle that surrounds all bounding boxes of all glyphs, in font units.
-    ///
-    /// This corresponds to the `xMin`/`xMax`/`yMin`/`yMax` values in the OpenType `head` table.
-    pub bounds: euclid::Rect<f32, ()>,
-}
-impl FontFaceMetrics {
-    /// Compute [`FontMetrics`] given a font size in pixels.
-    pub fn sized(&self, font_size_px: Px) -> FontMetrics {
-        let size_scale = 1.0 / self.units_per_em as f32 * font_size_px.0 as f32;
-        let s = move |f: f32| Px((f * size_scale).round() as i32);
-        FontMetrics {
-            size_scale,
-            ascent: s(self.ascent),
-            descent: s(self.descent),
-            line_gap: s(self.line_gap),
-            underline_position: s(self.underline_position),
-            underline_thickness: s(self.underline_thickness),
-            cap_height: s(self.cap_height),
-            x_height: (s(self.x_height)),
-            bounds: {
-                let b = self.bounds;
-                PxRect::new(
-                    PxPoint::new(s(b.origin.x), s(b.origin.y)),
-                    PxSize::new(s(b.size.width), s(b.size.height)),
-                )
-            },
-        }
-    }
-}
-
 /// Various metrics about a [`Font`].
-///
-/// You can compute these metrics from a [`FontFaceMetrics`]
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 pub struct FontMetrics {
-    /// Multiply this to a font EM value to get the size in pixels.
-    pub size_scale: f32,
-
     /// The maximum amount the font rises above the baseline, in pixels.
     pub ascent: Px,
 
@@ -3628,12 +3450,79 @@ pub struct FontMetrics {
     ///
     /// This corresponds to the `xMin`/`xMax`/`yMin`/`yMax` values in the OpenType `head` table.
     pub bounds: PxRect,
+
+    units_per_em: u16,
 }
 impl FontMetrics {
     /// The font line height.
     pub fn line_height(&self) -> Px {
         self.ascent - self.descent + self.line_gap
     }
+
+    fn new(f: &skrifa::FontRef, size: Px) -> Self {
+        let m = f.metrics(skrifa::instance::Size::new(size.0 as f32), skrifa::instance::LocationRef::default());
+        let u = m.underline.unwrap_or_default();
+        let b = m.bounds.unwrap_or_default();
+        let scale = size.0 as f32 / m.units_per_em as f32;
+        let line_gap = self::line_gap(f) as f32 * scale;
+        fn f32_to_px(v: f32) -> Px {
+            // use num_traits to cast
+            euclid::point2::<f32, ()>(v, v).cast().x
+        }
+        Self {
+            ascent: f32_to_px(m.ascent),
+            descent: f32_to_px(m.descent),
+            line_gap: f32_to_px(line_gap),
+            underline_position: f32_to_px(u.offset),
+            underline_thickness: f32_to_px(u.thickness),
+            cap_height: f32_to_px(m.cap_height.unwrap_or(0.0)),
+            x_height: f32_to_px(m.x_height.unwrap_or(0.0)),
+            bounds: euclid::rect(b.x_min, b.y_min, b.x_max - b.x_min, b.y_max - b.y_min).cast(),
+
+            units_per_em: m.units_per_em,
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            ascent: Px(0),
+            descent: Px(0),
+            line_gap: Px(0),
+            underline_position: Px(0),
+            underline_thickness: Px(0),
+            cap_height: Px(0),
+            x_height: Px(0),
+            bounds: euclid::Rect::zero(),
+            units_per_em: 0,
+        }
+    }
+}
+fn line_gap(f: &skrifa::FontRef) -> i16 {
+    // port of https://docs.rs/ttf-parser/latest/src/ttf_parser/lib.rs.html#1563-1585
+    use read_fonts::TableProvider as _;
+    if let Ok(os2) = f.os2() {
+        let use_typographic_metrics = os2.version() >= 4
+            && os2
+                .fs_selection()
+                .contains(read_fonts::tables::os2::SelectionFlags::USE_TYPO_METRICS);
+        if use_typographic_metrics {
+            return os2.s_typo_line_gap();
+        }
+    }
+    if let Ok(hrea) = f.hhea() {
+        if hrea.ascender().to_i16() == 0
+            && hrea.descender().to_i16() == 0
+            && let Ok(os2) = f.os2()
+        {
+            return if os2.s_typo_ascender() != 0 || os2.s_typo_descender() != 0 {
+                return os2.s_typo_line_gap();
+            } else {
+                0
+            };
+        }
+        return hrea.line_gap().to_i16();
+    }
+    0
 }
 
 /// Text transform function.
@@ -3977,7 +3866,7 @@ pub enum FontLoadingError {
     /// this error.
     NoSuchFontInCollection,
     /// Attempted to load a malformed or corrupted font.
-    Parse(ttf_parser::FaceParsingError),
+    Parse(read_fonts::ReadError),
     /// Attempted to load a font from the filesystem, but there is no filesystem (e.g. in
     /// WebAssembly).
     NoFilesystem,

--- a/crates/zng-ext-font/src/ligature_util.rs
+++ b/crates/zng-ext-font/src/ligature_util.rs
@@ -12,7 +12,7 @@ use core::cmp;
 use byteorder::{BigEndian, ReadBytesExt};
 use zng_view_api::font::GlyphIndex;
 
-const GDEF: u32 = u32::from_be_bytes(*b"GDEF");
+const GDEF: skrifa::Tag = skrifa::Tag::new(b"GDEF");
 
 #[derive(Clone)]
 pub struct LigatureCaretList {
@@ -29,8 +29,8 @@ impl LigatureCaretList {
         }
     }
 
-    pub fn load(font: &ttf_parser::RawFace) -> std::io::Result<Self> {
-        let table = match font.table(ttf_parser::Tag(GDEF)) {
+    pub(crate) fn load(font: &read_fonts::FontRef) -> std::io::Result<Self> {
+        let table = match font.table_data(GDEF) {
             Some(d) => d,
             None => return Ok(Self::empty()),
         };

--- a/crates/zng-ext-font/src/query_util.rs
+++ b/crates/zng-ext-font/src/query_util.rs
@@ -191,7 +191,7 @@ mod desktop {
             match ve {
                 font_kit::error::FontLoadingError::UnknownFormat => Self::UnknownFormat,
                 font_kit::error::FontLoadingError::NoSuchFontInCollection => Self::NoSuchFontInCollection,
-                font_kit::error::FontLoadingError::Parse => Self::Parse(ttf_parser::FaceParsingError::MalformedFont),
+                font_kit::error::FontLoadingError::Parse => Self::Parse(read_fonts::ReadError::MalformedData("")),
                 font_kit::error::FontLoadingError::NoFilesystem => Self::NoFilesystem,
                 font_kit::error::FontLoadingError::Io(e) => Self::Io(Arc::new(e)),
             }
@@ -371,11 +371,13 @@ mod android {
 
         for (_, path) in &lock[start_i..=end_i] {
             if let Ok(bytes) = FontBytes::from_file(path.clone()) {
-                if let Ok(f) = ttf_parser::Face::parse(&bytes, 0) {
+                if let Ok(f) = skrifa::FontRef::from_index(&bytes, 0) {
+                    use skrifa::MetadataProvider as _;
+                    let a = f.attributes();
                     candidates.push(matching::Properties {
-                        style: f.style(),
-                        weight: f.weight(),
-                        stretch: f.width(),
+                        style: a.style,
+                        weight: a.weight,
+                        stretch: a.stretch,
                     });
                     options.push(bytes);
                 }
@@ -419,7 +421,7 @@ mod android {
 
         //! Determines the closest font matching a description per the CSS Fonts Level 3 specification.
 
-        use ttf_parser::{Style, Weight, Width as Stretch};
+        use skrifa::attribute::{Stretch, Style, Weight};
 
         use crate::FontLoadingError;
 
@@ -439,22 +441,26 @@ mod android {
                 return Err(FontLoadingError::NoSuchFontInCollection);
             }
 
+            fn k(f: f32) -> i32 {
+                (f * 64.0) as i32
+            }
+
             // Step 4a (`font-stretch`).
             let matching_stretch = if matching_set.iter().any(|&index| candidates[index].stretch == query.stretch) {
                 // Exact match.
                 query.stretch
-            } else if query.stretch <= Stretch::Normal {
+            } else if query.stretch <= Stretch::NORMAL {
                 // Closest width, first checking narrower values and then wider values.
                 match matching_set
                     .iter()
                     .filter(|&&index| candidates[index].stretch < query.stretch)
-                    .min_by_key(|&&index| query.stretch.to_number() - candidates[index].stretch.to_number())
+                    .min_by_key(|&&index| k(query.stretch.ratio() - candidates[index].stretch.ratio()))
                 {
                     Some(&matching_index) => candidates[matching_index].stretch,
                     None => {
                         let matching_index = *matching_set
                             .iter()
-                            .min_by_key(|&&index| candidates[index].stretch.to_number() - query.stretch.to_number())
+                            .min_by_key(|&&index| k(candidates[index].stretch.ratio() - query.stretch.ratio()))
                             .unwrap();
                         candidates[matching_index].stretch
                     }
@@ -464,13 +470,13 @@ mod android {
                 match matching_set
                     .iter()
                     .filter(|&&index| candidates[index].stretch > query.stretch)
-                    .min_by_key(|&&index| candidates[index].stretch.to_number() - query.stretch.to_number())
+                    .min_by_key(|&&index| k(candidates[index].stretch.ratio() - query.stretch.ratio()))
                 {
                     Some(&matching_index) => candidates[matching_index].stretch,
                     None => {
                         let matching_index = *matching_set
                             .iter()
-                            .min_by_key(|&&index| query.stretch.to_number() - candidates[index].stretch.to_number())
+                            .min_by_key(|&&index| k(query.stretch.ratio() - candidates[index].stretch.ratio()))
                             .unwrap();
                         candidates[matching_index].stretch
                     }
@@ -480,9 +486,9 @@ mod android {
 
             // Step 4b (`font-style`).
             let style_preference = match query.style {
-                Style::Italic => [Style::Italic, Style::Oblique, Style::Normal],
-                Style::Oblique => [Style::Oblique, Style::Italic, Style::Normal],
-                Style::Normal => [Style::Normal, Style::Oblique, Style::Italic],
+                Style::Italic => [Style::Italic, Style::Oblique(None), Style::Normal],
+                Style::Oblique(_) => [Style::Oblique(None), Style::Italic, Style::Normal],
+                Style::Normal => [Style::Normal, Style::Oblique(None), Style::Italic],
             };
             let matching_style = *style_preference
                 .iter()
@@ -496,30 +502,30 @@ mod android {
             // just use 450 as the cutoff.
             let matching_weight = if matching_set.iter().any(|&index| candidates[index].weight == query.weight) {
                 query.weight
-            } else if query.weight.to_number() >= 400
-                && query.weight.to_number() < 450
-                && matching_set.iter().any(|&index| candidates[index].weight == Weight::from(500))
+            } else if query.weight.value() >= 400.0
+                && query.weight.value() < 450.0
+                && matching_set.iter().any(|&index| candidates[index].weight == Weight::new(500.0))
             {
                 // Check 500 first.
-                Weight::from(500)
-            } else if query.weight.to_number() >= 450
-                && query.weight.to_number() <= 500
-                && matching_set.iter().any(|&index| candidates[index].weight.to_number() == 400)
+                Weight::new(500.0)
+            } else if query.weight.value() >= 450.0
+                && query.weight.value() <= 500.0
+                && matching_set.iter().any(|&index| candidates[index].weight.value() == 400.0)
             {
                 // Check 400 first.
-                Weight::from(400)
-            } else if query.weight.to_number() <= 500 {
+                Weight::new(400.0)
+            } else if query.weight.value() <= 500.0 {
                 // Closest weight, first checking thinner values and then fatter ones.
                 match matching_set
                     .iter()
-                    .filter(|&&index| candidates[index].weight.to_number() <= query.weight.to_number())
-                    .min_by_key(|&&index| query.weight.to_number() - candidates[index].weight.to_number())
+                    .filter(|&&index| candidates[index].weight.value() <= query.weight.value())
+                    .min_by_key(|&&index| k(query.weight.value() - candidates[index].weight.value()))
                 {
                     Some(&matching_index) => candidates[matching_index].weight,
                     None => {
                         let matching_index = *matching_set
                             .iter()
-                            .min_by_key(|&&index| candidates[index].weight.to_number() - query.weight.to_number())
+                            .min_by_key(|&&index| k(candidates[index].weight.value() - query.weight.value()))
                             .unwrap();
                         candidates[matching_index].weight
                     }
@@ -528,14 +534,14 @@ mod android {
                 // Closest weight, first checking fatter values and then thinner ones.
                 match matching_set
                     .iter()
-                    .filter(|&&index| candidates[index].weight.to_number() >= query.weight.to_number())
-                    .min_by_key(|&&index| candidates[index].weight.to_number() - query.weight.to_number())
+                    .filter(|&&index| candidates[index].weight.value() >= query.weight.value())
+                    .min_by_key(|&&index| k(candidates[index].weight.value() - query.weight.value()))
                 {
                     Some(&matching_index) => candidates[matching_index].weight,
                     None => {
                         let matching_index = *matching_set
                             .iter()
-                            .min_by_key(|&&index| query.weight.to_number() - candidates[index].weight.to_number())
+                            .min_by_key(|&&index| k(query.weight.value() - candidates[index].weight.value()))
                             .unwrap();
                         candidates[matching_index].weight
                     }

--- a/crates/zng-ext-font/src/shaping.rs
+++ b/crates/zng-ext-font/src/shaping.rs
@@ -4,12 +4,13 @@ use std::{
     mem, ops,
 };
 
+use skrifa::MetadataProvider;
 use zng_app::widget::info::InlineSegmentInfo;
 use zng_ext_image::{ColorType, IMAGES, ImageDataFormat, ImageOptions, ImageSource, ImageVar};
 use zng_ext_l10n::{Lang, lang};
 use zng_layout::{
     context::{InlineConstraintsLayout, InlineConstraintsMeasure, InlineSegmentPos, LayoutDirection, TextSegmentKind},
-    unit::{Align, Factor2d, FactorUnits, Px, PxBox, PxConstraints2d, PxPoint, PxRect, PxSize, about_eq, euclid},
+    unit::{Align, FactorUnits, Px, PxBox, PxConstraints2d, PxPoint, PxRect, PxSize, about_eq, euclid},
 };
 use zng_txt::Txt;
 use zng_view_api::font::{GlyphIndex, GlyphInstance};
@@ -2270,7 +2271,7 @@ trait FontListRef {
         &self,
         seg: &str,
         word_ctx_key: &WordContextKey,
-        features: &[rustybuzz::Feature],
+        features: &[harfrust::Feature],
         out: impl FnOnce(&ShapedSegmentData, &Font) -> R,
     ) -> R;
 }
@@ -2279,7 +2280,7 @@ impl FontListRef for [Font] {
         &self,
         seg: &str,
         word_ctx_key: &WordContextKey,
-        features: &[rustybuzz::Feature],
+        features: &[harfrust::Feature],
         out: impl FnOnce(&ShapedSegmentData, &Font) -> R,
     ) -> R {
         let mut out = Some(out);
@@ -2528,7 +2529,7 @@ impl ShapedTextBuilder {
         static LIG: [&[u8]; 4] = [b"liga", b"clig", b"dlig", b"hlig"];
         let ligature_enabled = fonts[0].face().has_ligatures()
             && features.iter().any(|f| {
-                let tag = f.tag.to_bytes();
+                let tag = f.tag.to_be_bytes();
                 LIG.iter().any(|l| *l == tag)
             });
 
@@ -2814,16 +2815,20 @@ impl ShapedTextBuilder {
             self.out.has_colored_glyphs = true;
         }
         if (font.face().has_raster_images() || (cfg!(feature = "svg") && font.face().has_svg_images()))
-            && let Some(ttf) = font.face().ttf()
+            && let Some(ttf) = font.face().raw()
         {
             for (i, g) in shaped_seg.glyphs.iter().enumerate() {
-                let id = ttf_parser::GlyphId(g.index as _);
-                let ppm = font.size().0 as u16;
+                use read_fonts::TableProvider as _;
+                use skrifa::MetadataProvider as _;
+
+                let id = skrifa::GlyphId::new(g.index as _);
+                let ppm = skrifa::instance::Size::new(font.size().0 as f32);
                 let glyphs_i = self.out.glyphs.len() - shaped_seg.glyphs.len() + i;
-                if let Some(img) = ttf.glyph_raster_image(id, ppm) {
+                if let Some(img) = ttf.bitmap_strikes().glyph_for_size(ppm, id) {
                     self.push_glyph_raster(glyphs_i as _, img);
                 } else if cfg!(feature = "svg")
-                    && let Some(img) = ttf.glyph_svg_image(id)
+                    && let Ok(img) = ttf.svg()
+                    && let Ok(Some(img)) = img.glyph_data(id)
                 {
                     self.push_glyph_svg(glyphs_i as _, img);
                 }
@@ -2831,133 +2836,12 @@ impl ShapedTextBuilder {
         }
     }
 
-    fn push_glyph_raster(&mut self, glyphs_i: u32, img: ttf_parser::RasterGlyphImage) {
-        use ttf_parser::RasterImageFormat;
+    fn push_glyph_raster(&mut self, glyphs_i: u32, img: skrifa::bitmap::BitmapGlyph) {
         let size = PxSize::new(Px(img.width as _), Px(img.height as _));
-        let bgra_fmt = ImageDataFormat::Bgra8 {
-            size,
-            density: None,
-            original_color_type: ColorType::BGRA8,
-        };
-        let bgra_len = img.width as usize * img.height as usize * 4;
-        let (data, fmt) = match img.format {
-            RasterImageFormat::PNG => (img.data.to_vec(), ImageDataFormat::from("png")),
-            RasterImageFormat::BitmapMono => {
-                // row aligned 1-bitmap
-                let mut bgra = Vec::with_capacity(bgra_len);
-                let bytes_per_row = (img.width as usize).div_ceil(8);
-                for y in 0..img.height as usize {
-                    let row_start = y * bytes_per_row;
-                    for x in 0..img.width as usize {
-                        let byte_index = row_start + x / 8;
-                        let bit_index = 7 - (x % 8);
-                        let bit = (img.data[byte_index] >> bit_index) & 1;
-                        let color = if bit == 1 { [0, 0, 0, 255] } else { [255, 255, 255, 255] };
-                        bgra.extend_from_slice(&color);
-                    }
-                }
-                (bgra, bgra_fmt)
-            }
-            RasterImageFormat::BitmapMonoPacked => {
-                // packed 1-bitmap
-                let mut bgra = Vec::with_capacity(bgra_len);
-                for &c8 in img.data {
-                    for bit in 0..8 {
-                        let color = if (c8 >> (7 - bit)) & 1 == 1 {
-                            [0, 0, 0, 255]
-                        } else {
-                            [255, 255, 255, 255]
-                        };
-                        bgra.extend_from_slice(&color);
-                        if bgra.len() == bgra_len {
-                            break;
-                        }
-                    }
-                }
-                (bgra, bgra_fmt)
-            }
-            RasterImageFormat::BitmapGray2 => {
-                // row aligned 2-bitmap
-                let mut bgra = Vec::with_capacity(bgra_len);
-                let bytes_per_row = (img.width as usize).div_ceil(4);
-                for y in 0..img.height as usize {
-                    let row_start = y * bytes_per_row;
-                    for x in 0..img.width as usize {
-                        let byte_index = row_start + x / 4;
-                        let shift = (3 - (x % 4)) * 2;
-                        let gray = (img.data[byte_index] >> shift) & 0b11;
-                        let color = match gray {
-                            0b00 => [0, 0, 0, 255],       // Black
-                            0b01 => [85, 85, 85, 255],    // Dark gray
-                            0b10 => [170, 170, 170, 255], // Light gray
-                            0b11 => [255, 255, 255, 255], // White
-                            _ => unreachable!(),
-                        };
-                        bgra.extend_from_slice(&color);
-                    }
-                }
-                (bgra, bgra_fmt)
-            }
-            RasterImageFormat::BitmapGray2Packed => {
-                // packed 2-bitmap
-                let mut bgra = Vec::with_capacity(bgra_len);
-                for &c4 in img.data {
-                    for i in 0..4 {
-                        let gray = (c4 >> (7 - i * 2)) & 0b11;
-                        let color = match gray {
-                            0b00 => [0, 0, 0, 255],       // Black
-                            0b01 => [85, 85, 85, 255],    // Dark gray
-                            0b10 => [170, 170, 170, 255], // Light gray
-                            0b11 => [255, 255, 255, 255], // White
-                            _ => unreachable!(),
-                        };
-                        bgra.extend_from_slice(&color);
-                        if bgra.len() == bgra_len {
-                            break;
-                        }
-                    }
-                }
-                (bgra, bgra_fmt)
-            }
-            RasterImageFormat::BitmapGray4 => {
-                // row aligned 4-bitmap
-                let mut bgra = Vec::with_capacity(bgra_len);
-                let bytes_per_row = (img.width as usize).div_ceil(2);
-                for y in 0..img.height as usize {
-                    let row_start = y * bytes_per_row;
-                    for x in 0..img.width as usize {
-                        let byte_index = row_start + x / 2;
-                        let shift = if x % 2 == 0 { 4 } else { 0 };
-                        let gray = (img.data[byte_index] >> shift) & 0b1111;
-                        let g = gray * 17;
-                        bgra.extend_from_slice(&[g, g, g, 255]);
-                    }
-                }
-                (bgra, bgra_fmt)
-            }
-            RasterImageFormat::BitmapGray4Packed => {
-                let mut bgra = Vec::with_capacity(bgra_len);
-                for &c2 in img.data {
-                    for i in 0..2 {
-                        let gray = (c2 >> (7 - i * 4)) & 0b1111;
-                        let g = gray * 17;
-                        bgra.extend_from_slice(&[g, g, g, 255]);
-                        if bgra.len() == bgra_len {
-                            break;
-                        }
-                    }
-                }
-                (bgra, bgra_fmt)
-            }
-            RasterImageFormat::BitmapGray8 => {
-                let mut bgra = Vec::with_capacity(bgra_len);
-                for &c in img.data {
-                    bgra.extend_from_slice(&[c, c, c, 255]);
-                }
-                (bgra, bgra_fmt)
-            }
-            RasterImageFormat::BitmapPremulBgra32 => {
-                let mut bgra = img.data.to_vec();
+
+        let (data, fmt) = match img.data {
+            skrifa::bitmap::BitmapData::Bgra(d) => {
+                let mut bgra = d.to_vec();
                 for c in bgra.chunks_exact_mut(4) {
                     let (b, g, r, a) = (c[0], c[1], c[2], c[3]);
                     let unp = if a == 255 {
@@ -2971,14 +2855,30 @@ impl ShapedTextBuilder {
                     };
                     c.copy_from_slice(&unp);
                 }
+                let bgra_fmt = ImageDataFormat::Bgra8 {
+                    size,
+                    density: None,
+                    original_color_type: ColorType::BGRA8,
+                };
                 (bgra, bgra_fmt)
+            }
+            skrifa::bitmap::BitmapData::Png(d) => (d.to_vec(), ImageDataFormat::from("png")),
+            skrifa::bitmap::BitmapData::Mask(d) => {
+                let d = match d.decode(img.width, img.height) {
+                    Ok(g) => g,
+                    Err(e) => {
+                        tracing::error!("cannot decode glyph bitmap mask, {e:?}");
+                        vec![0; img.width as usize * img.height as usize]
+                    }
+                };
+                (d, ImageDataFormat::A8 { size })
             }
         };
         self.push_glyph_img(glyphs_i, ImageSource::from((data, fmt)));
     }
 
-    fn push_glyph_svg(&mut self, glyphs_i: u32, img: ttf_parser::svg::SvgDocument) {
-        self.push_glyph_img(glyphs_i, ImageSource::from((img.data, ImageDataFormat::from("svg"))));
+    fn push_glyph_svg(&mut self, glyphs_i: u32, img: &[u8]) {
+        self.push_glyph_img(glyphs_i, ImageSource::from((img, ImageDataFormat::from("svg"))));
     }
 
     fn push_glyph_img(&mut self, glyphs_i: u32, source: ImageSource) {
@@ -4353,12 +4253,13 @@ impl WordContextKey {
         if !font_features.is_empty() {
             features.reserve(font_features.len() * if is_64 { 3 } else { 4 });
             for feature in font_features {
+                let tag = u32::from_be_bytes(feature.tag.to_be_bytes());
                 if is_64 {
-                    let mut h = feature.tag.0 as u64;
+                    let mut h = tag as u64;
                     h |= (feature.value as u64) << 32;
                     features.push(h as usize);
                 } else {
-                    features.push(feature.tag.0 as usize);
+                    features.push(tag as usize);
                     features.push(feature.value as usize);
                 }
 
@@ -4375,17 +4276,17 @@ impl WordContextKey {
         }
     }
 
-    pub fn harfbuzz_lang(&self) -> Option<rustybuzz::Language> {
+    pub fn harfbuzz_lang(&self) -> Option<harfrust::Language> {
         self.lang.as_str().parse().ok()
     }
 
-    pub fn harfbuzz_script(&self) -> Option<rustybuzz::Script> {
+    pub fn harfbuzz_script(&self) -> Option<harfrust::Script> {
         let t: u32 = self.script?.into();
         let t = t.to_le_bytes(); // Script is a TinyStr4 that uses LE
-        rustybuzz::Script::from_iso15924_tag(ttf_parser::Tag::from_bytes(&[t[0], t[1], t[2], t[3]]))
+        harfrust::Script::from_iso15924_tag(skrifa::Tag::new(&[t[0], t[1], t[2], t[3]]))
     }
 
-    pub fn harfbuzz_direction(&self) -> rustybuzz::Direction {
+    pub fn harfbuzz_direction(&self) -> harfrust::Direction {
         into_harf_direction(self.direction)
     }
 }
@@ -4406,10 +4307,10 @@ struct ShapedGlyph {
 }
 
 impl Font {
-    fn buffer_segment(&self, segment: &str, key: &WordContextKey) -> rustybuzz::UnicodeBuffer {
-        let mut buffer = rustybuzz::UnicodeBuffer::new();
+    fn buffer_segment(&self, segment: &str, key: &WordContextKey) -> harfrust::UnicodeBuffer {
+        let mut buffer = harfrust::UnicodeBuffer::new();
         buffer.set_direction(key.harfbuzz_direction());
-        buffer.set_cluster_level(rustybuzz::BufferClusterLevel::MonotoneCharacters);
+        buffer.set_cluster_level(harfrust::BufferClusterLevel::MonotoneCharacters);
 
         if let Some(lang) = key.harfbuzz_lang() {
             buffer.set_language(lang);
@@ -4422,10 +4323,14 @@ impl Font {
         buffer
     }
 
-    fn shape_segment_no_cache(&self, seg: &str, key: &WordContextKey, features: &[rustybuzz::Feature]) -> ShapedSegmentData {
-        let buffer = if let Some(font) = self.harfbuzz() {
+    fn shape_segment_no_cache(&self, seg: &str, key: &WordContextKey, features: &[harfrust::Feature]) -> ShapedSegmentData {
+        let buffer = if let Some(font) = self.face().raw()
+            && let Some(shaper_data) = &self.0.shaper_cache
+        {
             let buffer = self.buffer_segment(seg, key);
-            rustybuzz::shape(&font, features, buffer)
+            let shaper_builder = shaper_data.shaper(&font);
+            let shaper = shaper_builder.build();
+            shaper.shape(buffer, harfrust::ShapeOptions::new().features(features))
         } else {
             return ShapedSegmentData {
                 glyphs: vec![],
@@ -4434,7 +4339,7 @@ impl Font {
             };
         };
 
-        let size_scale = self.metrics().size_scale;
+        let size_scale = self.0.size.0 as f32 / self.0.metrics.units_per_em as f32;
         let to_layout = |p: i32| p as f32 * size_scale;
 
         let mut w_x_advance = 0.0;
@@ -4473,7 +4378,7 @@ impl Font {
         &self,
         seg: &str,
         word_ctx_key: &WordContextKey,
-        features: &[rustybuzz::Feature],
+        features: &[harfrust::Feature],
         out: impl FnOnce(&ShapedSegmentData) -> R,
     ) -> R {
         if !(1..=WORD_CACHE_MAX_LEN).contains(&seg.len()) || self.face().is_empty() {
@@ -4584,27 +4489,37 @@ impl Font {
     pub fn outline(&self, glyph_id: GlyphIndex, sink: &mut impl OutlineSink) -> Option<PxRect> {
         struct AdapterSink<'a, S> {
             sink: &'a mut S,
-            scale: f32,
+            bounds: euclid::Box2D<f32, Px>,
         }
-        impl<S: OutlineSink> ttf_parser::OutlineBuilder for AdapterSink<'_, S> {
+        impl<S> AdapterSink<'_, S> {
+            fn point(&mut self, x: f32, y: f32) -> euclid::Point2D<f32, Px> {
+                let p = euclid::point2(x, y);
+                self.bounds.min = self.bounds.min.min(p);
+                self.bounds.max = self.bounds.max.max(p);
+                p
+            }
+        }
+        impl<S: OutlineSink> skrifa::outline::OutlinePen for AdapterSink<'_, S> {
             fn move_to(&mut self, x: f32, y: f32) {
-                self.sink.move_to(euclid::point2(x, y) * self.scale)
+                let p = self.point(x, y);
+                self.sink.move_to(p)
             }
 
             fn line_to(&mut self, x: f32, y: f32) {
-                self.sink.line_to(euclid::point2(x, y) * self.scale)
+                let p = self.point(x, y);
+                self.sink.line_to(p)
             }
 
             fn quad_to(&mut self, x1: f32, y1: f32, x: f32, y: f32) {
-                let ctrl = euclid::point2(x1, y1) * self.scale;
-                let to = euclid::point2(x, y) * self.scale;
+                let ctrl = self.point(x1, y1);
+                let to = self.point(x, y);
                 self.sink.quadratic_curve_to(ctrl, to)
             }
 
             fn curve_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x: f32, y: f32) {
-                let l_from = euclid::point2(x1, y1) * self.scale;
-                let l_to = euclid::point2(x2, y2) * self.scale;
-                let to = euclid::point2(x, y) * self.scale;
+                let l_from = self.point(x1, y1);
+                let l_to = self.point(x2, y2);
+                let to = self.point(x, y);
                 self.sink.cubic_curve_to((l_from, l_to), to)
             }
 
@@ -4612,17 +4527,20 @@ impl Font {
                 self.sink.close()
             }
         }
+        let size = skrifa::instance::Size::new(self.size().0 as f32);
 
-        let scale = self.metrics().size_scale;
-
-        let f = self.harfbuzz()?;
-        let r = f.outline_glyph(ttf_parser::GlyphId(glyph_id as _), &mut AdapterSink { sink, scale })?;
-        Some(
-            PxRect::new(
-                PxPoint::new(Px(r.x_min as _), Px(r.y_min as _)),
-                PxSize::new(Px(r.width() as _), Px(r.height() as _)),
-            ) * Factor2d::uniform(scale),
+        let f = self.face().raw()?;
+        let o = f.outline_glyphs().get(skrifa::GlyphId::new(glyph_id))?;
+        let mut sink = AdapterSink {
+            sink,
+            bounds: euclid::Box2D::zero(),
+        };
+        o.draw(
+            skrifa::outline::DrawSettings::unhinted(size, skrifa::instance::LocationRef::default()),
+            &mut sink,
         )
+        .ok()?;
+        Some(sink.bounds.to_rect().cast())
     }
 
     /// Ray cast an horizontal line across the glyph and returns the entry and exit hits.
@@ -4812,10 +4730,10 @@ pub fn f32_cmp(a: &f32, b: &f32) -> std::cmp::Ordering {
     a.partial_cmp(b).unwrap()
 }
 
-fn into_harf_direction(d: LayoutDirection) -> rustybuzz::Direction {
+fn into_harf_direction(d: LayoutDirection) -> harfrust::Direction {
     match d {
-        LayoutDirection::LTR => rustybuzz::Direction::LeftToRight,
-        LayoutDirection::RTL => rustybuzz::Direction::RightToLeft,
+        LayoutDirection::LTR => harfrust::Direction::LeftToRight,
+        LayoutDirection::RTL => harfrust::Direction::RightToLeft,
     }
 }
 

--- a/crates/zng/src/font.rs
+++ b/crates/zng/src/font.rs
@@ -157,11 +157,11 @@
 
 pub use zng_ext_font::{
     BidiLevel, CaretIndex, ColorGlyph, ColorGlyphs, ColorPalette, ColorPaletteType, ColorPalettes, CustomFont, FONT_CHANGED_EVENT, FONTS,
-    Font, FontBytes, FontChange, FontChangedArgs, FontColorPalette, FontFace, FontFaceList, FontFaceMetrics, FontList, FontMetrics,
-    FontName, FontNames, FontSize, FontStretch, FontStyle, FontWeight, HYPHENATION, HyphenationDataDir, HyphenationDataSource, Hyphens,
-    Justify, LayoutDirections, LetterSpacing, LineBreak, LineHeight, LineSpacing, OutlineSink, ParagraphSpacing, SegmentedText,
-    SegmentedTextIter, ShapedColoredGlyphs, ShapedLine, ShapedSegment, ShapedText, TabLength, TextLineThickness, TextOverflowInfo,
-    TextSegment, TextSegmentKind, TextShapingArgs, TextTransformFn, UnderlineThickness, WhiteSpace, WordBreak, WordSpacing, font_features,
+    Font, FontBytes, FontChange, FontChangedArgs, FontColorPalette, FontFace, FontFaceList, FontList, FontMetrics, FontName, FontNames,
+    FontSize, FontStretch, FontStyle, FontWeight, HYPHENATION, HyphenationDataDir, HyphenationDataSource, Hyphens, Justify,
+    LayoutDirections, LetterSpacing, LineBreak, LineHeight, LineSpacing, OutlineSink, ParagraphSpacing, SegmentedText, SegmentedTextIter,
+    ShapedColoredGlyphs, ShapedLine, ShapedSegment, ShapedText, TabLength, TextLineThickness, TextOverflowInfo, TextSegment,
+    TextSegmentKind, TextShapingArgs, TextTransformFn, UnderlineThickness, WhiteSpace, WordBreak, WordSpacing, font_features,
     unicode_bidi_levels, unicode_bidi_sort,
 };
 pub use zng_view_api::config::FontAntiAliasing;


### PR DESCRIPTION
Both `ttf-parser` and `rustybuzz` have been declared "unmaintained" by rustsec. Replaced with `skrifa`, `read-fonts` and `harfrust`

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->