### PR TITLE
Workaround `remove_dir_all` broken build

### DIFF
--- a/crates/zng-task/Cargo.toml
+++ b/crates/zng-task/Cargo.toml
@@ -75,7 +75,6 @@ once_cell = { version = "1.19", default-features = false, features = [
 ], optional = true }
 sha2 = { version = "0.11", default-features = false, optional = true }
 base64 = { version = "0.22", default-features = false, features = ["std"], optional = true }
-remove_dir_all = { version = "1", default-features = false, optional = true }
 dunce = { version = "1.0", default-features = false }
 serde_bytes = { version = "0.11", features = ["std"], default-features = false }
 
@@ -90,6 +89,9 @@ flate2 = { version = "1.1.5", default-features = false, features = ["rust_backen
 async-compression = { version = "0.4.34", default-features = false, features = ["futures-io", "zstd", "brotli", "gzip"], optional = true }
 bytemuck = { version = "1.24.0", default-features = false, features = ["extern_crate_alloc"] }
 self_cell = "1.2.2"
+
+[target.'cfg(windows)'.dependencies]
+remove_dir_all = { version = "1", default-features = false, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ipc-channel = { version = "0.22", default-features = false, optional = true }

--- a/crates/zng-task/src/http.rs
+++ b/crates/zng-task/src/http.rs
@@ -710,3 +710,8 @@ pub async fn send(request: Request) -> Result<Response, Error> {
         }
     }
 }
+
+#[cfg(windows)]
+pub use remove_dir_all::remove_dir_all;
+#[cfg(not(windows))]
+pub use std::fs::remove_dir_all;

--- a/crates/zng-task/src/http/file_cache.rs
+++ b/crates/zng-task/src/http/file_cache.rs
@@ -399,7 +399,7 @@ impl CacheEntry {
     }
 
     fn try_delete_dir(dir: &Path) {
-        let _ = remove_dir_all::remove_dir_all(dir);
+        let _ = crate::http::remove_dir_all(dir);
     }
 
     fn writing_tag(&self) -> Option<PathBuf> {

--- a/crates/zng-task/src/http/util.rs
+++ b/crates/zng-task/src/http/util.rs
@@ -142,7 +142,7 @@ pub struct TestTempDir {
 impl Drop for TestTempDir {
     fn drop(&mut self) {
         if let Some(path) = self.path.take() {
-            let _ = remove_dir_all::remove_dir_all(path);
+            let _ = crate::http::remove_dir_all(path);
         }
     }
 }

--- a/tools/cargo-do/Cargo.toml
+++ b/tools/cargo-do/Cargo.toml
@@ -13,4 +13,6 @@ regex = "1.10"
 topological-sort = "0.2"
 dunce = "1.0"
 itertools = "0.15.0"
+
+[target.'cfg(windows)'.dependencies]
 remove_dir_all = "1.0"

--- a/tools/cargo-do/src/main.rs
+++ b/tools/cargo-do/src/main.rs
@@ -458,12 +458,12 @@ fn check_all_features(mut args: Vec<&str>) {
                 if prev_dir != std::path::PathBuf::new() {
                     self::clean(vec![]);
                 }
-                let _ = remove_dir_all::remove_dir_all(&dir);
+                let _ = util::remove_dir_all(&dir);
                 std::fs::create_dir_all(&dir).unwrap();
                 current_full_build_dir = dir;
                 std::env::set_current_dir(&current_full_build_dir).unwrap();
                 if prev_dir != std::path::PathBuf::new()
-                    && let Err(e) = remove_dir_all::remove_dir_all(&prev_dir)
+                    && let Err(e) = util::remove_dir_all(&prev_dir)
                 {
                     error(f!("failed to cleanup `{}`, {e}", prev_dir.display()));
                 }
@@ -526,7 +526,7 @@ fn check_all_features(mut args: Vec<&str>) {
     }
     if full_build && current_full_build_dir != std::path::PathBuf::new() {
         self::clean(vec![]);
-        if let Err(e) = remove_dir_all::remove_dir_all(&current_full_build_dir) {
+        if let Err(e) = util::remove_dir_all(&current_full_build_dir) {
             error(f!("failed to cleanup `{}`, {e}", current_full_build_dir.display()));
         }
     }
@@ -570,7 +570,7 @@ fn l10n(mut args: Vec<&str>) {
         let template = output.join("template");
 
         if !check
-            && let Err(e) = remove_dir_all::remove_dir_all(&template)
+            && let Err(e) = util::remove_dir_all(&template)
             && !matches!(e.kind(), std::io::ErrorKind::NotFound)
         {
             error(f!("cannot clear `{}`, {e}", output.display()));
@@ -884,7 +884,7 @@ fn run_wasm(mut args: Vec<&str>) {
     }
 
     let out_dir = format!("{}/target/run-wasm/{example}", std::env::current_dir().unwrap().display());
-    let _ = remove_dir_all::remove_dir_all(&out_dir);
+    let _ = util::remove_dir_all(&out_dir);
     let _ = std::fs::create_dir_all(&out_dir);
 
     cmd_req(
@@ -1158,7 +1158,7 @@ fn build_apk(mut args: Vec<&str>) {
     // cargo zng res (.zr-apk)
     let apk_dir = std::path::PathBuf::from(format!("target/build-apk/{example}/source.apk"));
     let _ = std::fs::remove_file(&apk_dir);
-    let _ = remove_dir_all::remove_dir_all(&apk_dir);
+    let _ = util::remove_dir_all(&apk_dir);
     let _ = std::fs::create_dir_all(&apk_dir);
     let apk_dir = dunce::canonicalize(apk_dir).unwrap();
     let mut build_args = vec!["build", "-p", &example];
@@ -1213,7 +1213,7 @@ fn build_apk(mut args: Vec<&str>) {
 
     let target_dir = format!("target/build-apk/{example}.apk");
     let _ = std::fs::remove_file(&target_dir);
-    let _ = remove_dir_all::remove_dir_all(&target_dir);
+    let _ = util::remove_dir_all(&target_dir);
 
     cmd_req(
         &cargo_zng,
@@ -1230,7 +1230,7 @@ fn build_apk(mut args: Vec<&str>) {
     );
 
     // cleanup
-    let _ = remove_dir_all::remove_dir_all(apk_dir.parent().unwrap());
+    let _ = util::remove_dir_all(apk_dir.parent().unwrap());
 }
 
 // do build-ios <EXAMPLE>
@@ -1332,7 +1332,7 @@ fn clean(mut args: Vec<&str>) {
 
         cmd("cargo", &["clean"], &args);
     } else if temp {
-        match remove_dir_all::remove_dir_all("target/tmp") {
+        match util::remove_dir_all("target/tmp") {
             Ok(_) => match std::fs::create_dir("target/tmp") {
                 Ok(_) => println("removed `target/tmp` contents"),
                 Err(_) => println("removed `target/tmp`"),
@@ -1769,7 +1769,7 @@ fn semver_check(args: Vec<&str>) {
                 &args,
             );
             for t in util::glob("target/semver-checks/*/target") {
-                let _ = remove_dir_all::remove_dir_all(t);
+                let _ = util::remove_dir_all(t);
             }
         }
     }

--- a/tools/cargo-do/src/util.rs
+++ b/tools/cargo-do/src/util.rs
@@ -791,3 +791,8 @@ pub fn get_git_diff(from: &str, to: &str) -> String {
 
     String::from_utf8(output.stdout).unwrap()
 }
+
+#[cfg(windows)]
+pub use remove_dir_all::remove_dir_all;
+#[cfg(not(windows))]
+pub use std::fs::remove_dir_all;


### PR DESCRIPTION
We only use this crate to improve dir removal on Windows, the build is broken on Unix. This change makes it a `cfg(windows)` only dependency.