### PR TITLE
Fix deprecated warning in `glob`

### DIFF
--- a/tests/macro-tests/src/run.rs
+++ b/tests/macro-tests/src/run.rs
@@ -29,7 +29,7 @@ fn cleanup(test: &str) {
     let cases = glob::glob(&format!("cases/{test}.stderr")).expect("cleanup glob error");
     for case in cases {
         let cleanup_case = move || {
-            let case = case.map_err(glob::GlobError::into_error)?;
+            let case = case.map_err(std::io::Error::from)?;
             let raw = fs::read_to_string(&case)?;
 
             let mut clean = String::with_capacity(raw.len());


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->