### PR TITLE
Replace deflate dependencies

### DIFF
--- a/crates/zng-tp-licenses/Cargo.toml
+++ b/crates/zng-tp-licenses/Cargo.toml
@@ -12,9 +12,9 @@ keywords = ["gui", "ui", "user-interface", "zng"]
 
 [features]
 # Include helpers for collecting third-party licenses.
-build = ["dep:serde_json", "dep:deflate", "dep:postcard"]
+build = ["dep:serde_json", "dep:flate2", "dep:postcard"]
 # Include helpers for deserializing `build` encoded licenses.
-embed = ["dep:inflate", "dep:postcard"]
+embed = ["dep:flate2", "dep:postcard"]
 
 # Internal feature, only enabled if built with --all-features
 _all_features = []
@@ -25,9 +25,8 @@ zng-txt = { path = "../zng-txt", version = "0.6.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 serde_json = { version = "1.0", default-features = false, features = ["std"], optional = true }
-deflate = { version = "1.0", default-features = false, optional = true }
-inflate = { version = "0.4", default-features = false, optional = true }
-postcard = { version = "1", default-features = false, features = ["alloc"], optional = true }
+flate2 = { version = "1.0", default-features = false, optional = true, features = ["rust_backend"] }
+postcard = { version = "1", default-features = false, features = ["use-std"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 tempfile = { version = "3.10", default-features = false }

--- a/crates/zng-tp-licenses/src/lib.rs
+++ b/crates/zng-tp-licenses/src/lib.rs
@@ -311,7 +311,12 @@ pub fn parse_cargo_about(json: &str) -> Result<Vec<LicenseUsed>, serde_json::Err
 /// Panics in case of any error.
 #[cfg(feature = "build")]
 pub fn encode_licenses(licenses: &[LicenseUsed]) -> Vec<u8> {
-    deflate::deflate_bytes(&postcard::to_allocvec(licenses).expect("postard error"))
+    let mut r = vec![];
+    {
+        let mut encoder = flate2::write::DeflateEncoder::new(&mut r, flate2::Compression::default());
+        postcard::to_io(licenses, &mut encoder).expect("postcard error");
+    }
+    r
 }
 
 /// Encode licenses and write to the output file that is included by [`decode_embedding!`].
@@ -341,6 +346,7 @@ macro_rules! decode_embedding {
 /// if both encoding and decoding is made with the same `Cargo.lock` dependencies.
 #[cfg(feature = "embed")]
 pub fn decode_licenses(bin: &[u8]) -> Vec<LicenseUsed> {
-    let bin = inflate::inflate_bytes(bin).expect("invalid deflate binary");
-    postcard::from_bytes(&bin).expect("invalid postard binary")
+    let bin = flate2::read::DeflateDecoder::new(bin);
+    let mut scratch = [0u8; 1024];
+    postcard::from_io((bin, &mut scratch)).expect("invalid postard binary").0
 }


### PR DESCRIPTION
Replace `deflate` and `inflate` with `flate2` that is better maintained

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->