### PR TITLE
Fix new nightly lint

### DIFF
--- a/crates/zng-app-proc-macros/src/util.rs
+++ b/crates/zng-app-proc-macros/src/util.rs
@@ -33,7 +33,7 @@ pub fn parse_braces<'a>(input: &syn::parse::ParseBuffer<'a>) -> syn::Result<(syn
 }
 
 /// Returns `true` if the proc-macro is running in one of the rust-analyzer proc-macro servers.
-#[expect(unexpected_cfgs)] // rust_analyzer exists: https://github.com/rust-lang/rust-analyzer/pull/15528
+#[allow(unexpected_cfgs)] // TODO(breaking) rustc added `rust_analyzer` to the list https://github.com/rust-lang/rust/pull/160878
 pub fn is_rust_analyzer() -> bool {
     cfg!(rust_analyzer)
 }


### PR DESCRIPTION
This one causes a warning in stable if fully fixed, so I changed it to avoid the warning on both.

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->