### PR TITLE
Refactor setup API to support partial operations

### DIFF
--- a/crates/zng-ext-setup/src/service.rs
+++ b/crates/zng-ext-setup/src/service.rs
@@ -247,14 +247,9 @@ pub struct SetupError {
     ///
     /// Each task is identified by index on the operation, type and name.
     pub task_errors: Vec<((usize, TaskTypeId, Txt), SetupTaskError)>,
-    /// If canceled successfully.
-    ///
-    /// If this is `true` and has no errors the operation was canceled by request.
-    ///
-    /// If this is `true` and has errors the tasks managed to cleanup or had not started yet.
-    ///
-    /// If this is `false` and has errors some tasks already made irreversible changes, the installation is probably corrupted.
-    pub canceled: bool,
+
+    /// Operation state after not completing successfully.
+    pub state: SetupErrorState,
 }
 impl SetupError {
     /// No actual error, canceled by request.
@@ -262,7 +257,7 @@ impl SetupError {
         Self {
             op_error: None,
             task_errors: vec![],
-            canceled: true,
+            state: SetupErrorState::Canceled,
         }
     }
 
@@ -270,23 +265,23 @@ impl SetupError {
     ///
     /// Each task is identified by index on the operation, type and name.
     ///
-    /// If the tasks managed to reverse all system changes `canceled` must be `true`.
-    pub fn task_errors(errors: Vec<((usize, TaskTypeId, Txt), SetupTaskError)>, canceled: bool) -> Self {
+    /// If the tasks managed to reverse all changes before committing the `state` must be `Canceled`.
+    pub fn task_errors(errors: Vec<((usize, TaskTypeId, Txt), SetupTaskError)>, state: SetupErrorState) -> Self {
         Self {
             op_error: None,
             task_errors: errors,
-            canceled,
+            state,
         }
     }
 
     /// Operation failed with error associated with operation itself that affects all tasks.
     ///
-    /// If the error is detected before any task runs `canceled` should be `true`.
-    pub fn op_error(error: SetupTaskError, canceled: bool) -> Self {
+    /// If the error is detected before any task runs and any non-destructive change was made the `state` must be `Canceled`.
+    pub fn op_error(error: SetupTaskError, state: SetupErrorState) -> Self {
         Self {
             op_error: Some(error),
             task_errors: vec![],
-            canceled,
+            state,
         }
     }
 
@@ -300,8 +295,55 @@ impl SetupError {
             }
         }
         impl std::error::Error for CorruptedOpConfig {}
-        Self::op_error(SetupTaskError::CorruptedTaskData(Arc::new(CorruptedOpConfig(config_name))), true)
+        Self::op_error(
+            SetupTaskError::CorruptedTaskData(Arc::new(CorruptedOpConfig(config_name))),
+            SetupErrorState::Canceled,
+        )
     }
+}
+
+/// Represents state of a setup operation that ended in a [`SetupError`].
+#[derive(Clone, PartialEq, Debug)]
+pub enum SetupErrorState {
+    /// Canceled successfully, all changes where reverted.
+    ///
+    /// The operation is canceled by request or by error before it starts committing irreversible changes,
+    /// either way the system and any previous installation is not affected when ended in this state.
+    Canceled,
+
+    /// Install operation failed before it started making irreversible changes and failed to cleanup
+    /// temporary changes.
+    ///
+    /// When an install fails during the preparing phase it automatically attempts to *cancel*, this is
+    /// the error when that cancel fails. If the install was an update the previous version will still be valid.
+    PartialPrepareInstall,
+
+    /// Install operation failed while making irreversible changes to the system.
+    ///
+    /// Operation attempts to complete as much of the install as possible, the associated `data`
+    /// can be used to uninstall the committed changes. Well designed tasks will cleanup all temporary
+    /// *prepared* data on error and generate uninstall data that cleanups even partial written files, but
+    /// there is no guarantee that this data will fully uninstall every change.
+    ///
+    /// If the operation was replacing a previous install (update or repair) the `data` will also
+    /// uninstall the previous installation.
+    PartialInstall {
+        /// Data that can uninstall all the successfully committed changes made during the failed install.
+        data: UninstallConfig,
+        /// Tasks that failed without generating uninstall data.
+        ///
+        /// If this is not empty uninstalling `data` will definitely not fully cleanup the broken install.
+        ///
+        /// Tasks are identified by index on the operation, type and name.
+        no_data: Vec<(usize, TaskTypeId, Txt)>,
+    },
+    /// Uninstall operation failed while making irreversible changes to the system.
+    ///
+    /// Operation attempts to complete as much of the uninstall as possible, so all tasks without error
+    /// have completed successfully.
+    ///
+    ///
+    PartialUninstall,
 }
 
 /// Represents status of [`SETUP`].
@@ -538,11 +580,12 @@ async fn prepare_install(config: InstallConfig, update: Option<UninstallConfig>)
 
         // cancel due to error
         if let Err(mut ce) = cancel_prepared(prepared_cfg).await {
-            ce.canceled = false;
+            // did not cleanup prepared either.
+            ce.state = SetupErrorState::PartialPrepareInstall;
             ce.task_errors.insert(0, e);
             Err(ce)
         } else {
-            Err(SetupError::task_errors(vec![e], true))
+            Err(SetupError::task_errors(vec![e], SetupErrorState::Canceled))
         }
     } else if cancel.get() {
         // cancel due to request
@@ -624,7 +667,7 @@ async fn cancel_prepared(config: PreparedInstallConfig) -> Result<(), SetupError
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(SetupError::task_errors(errors, false))
+        Err(SetupError::task_errors(errors, SetupErrorState::PartialPrepareInstall))
     }
 }
 
@@ -638,6 +681,7 @@ async fn commit_install(config: PreparedInstallConfig) -> Result<UninstallConfig
 
     let mut errors = vec![];
     let mut uninstall_cfg = vec![];
+    let mut err_no_clean = vec![];
 
     for (i, (id, cfg)) in config.tasks.iter().zip(config.cfg).enumerate() {
         let task_progress = var(Progress::indeterminate());
@@ -664,15 +708,22 @@ async fn commit_install(config: PreparedInstallConfig) -> Result<UninstallConfig
 
         // run task
         let task_ty = SETUP_SV.read().task_type(&id.0);
-        let error = match task_ty {
+        let mut error = None;
+        match task_ty {
             Ok(task_ty) => match (task_ty.install)(cfg, task_progress.clone()).await {
                 Ok(c) => {
                     uninstall_cfg.push(c);
-                    None
                 }
-                Err(e) => Some(e),
+                Err(e) => {
+                    error = Some(e.error);
+                    if let Some(d) = e.clean_data {
+                        uninstall_cfg.push(d);
+                    } else {
+                        err_no_clean.push((i, id.0.clone(), id.1.clone()));
+                    }
+                }
             },
-            Err(e) => Some(e),
+            Err(e) => error = Some(e),
         };
 
         if let Some(e) = error {
@@ -694,6 +745,11 @@ async fn commit_install(config: PreparedInstallConfig) -> Result<UninstallConfig
         }
     }
 
+    let mut tasks = config.tasks;
+    tasks.reverse();
+    uninstall_cfg.reverse();
+    let data = UninstallConfig { tasks, cfg: uninstall_cfg };
+
     if errors.is_empty() {
         // ensure general status updates to complete
         status.modify(clmv!(|a| {
@@ -702,12 +758,15 @@ async fn commit_install(config: PreparedInstallConfig) -> Result<UninstallConfig
             }
         }));
 
-        let mut tasks = config.tasks;
-        tasks.reverse();
-        uninstall_cfg.reverse();
-        Ok(UninstallConfig { tasks, cfg: uninstall_cfg })
+        Ok(data)
     } else {
-        Err(SetupError::task_errors(errors, false))
+        Err(SetupError::task_errors(
+            errors,
+            SetupErrorState::PartialInstall {
+                data,
+                no_data: err_no_clean,
+            },
+        ))
     }
 }
 
@@ -780,7 +839,7 @@ async fn uninstall(config: UninstallConfig) -> Result<(), SetupError> {
         }));
         Ok(())
     } else {
-        Err(SetupError::task_errors(errors, false))
+        Err(SetupError::task_errors(errors, SetupErrorState::PartialUninstall))
     }
 }
 
@@ -871,6 +930,6 @@ async fn validate_uninstall(config: UninstallConfig) -> Result<UninstallConfig, 
         }));
         Ok(UninstallConfig { tasks, cfg })
     } else {
-        Err(SetupError::task_errors(errors, canceled))
+        Err(SetupError::task_errors(errors, SetupErrorState::Canceled))
     }
 }

--- a/crates/zng-ext-setup/src/service.rs
+++ b/crates/zng-ext-setup/src/service.rs
@@ -10,9 +10,6 @@ use zng_var::{ResponderVar, ResponseVar, Var, VarEq, VarValue, const_var, respon
 
 use crate::task::{SetupTask, SetupTaskError, SetupTaskType, TaskTypeId};
 
-/// Result type for [`SETUP`] operations.
-pub type Result<T> = std::result::Result<T, SetupError>;
-
 /// Setup service.
 ///
 /// This service runs [install] and [uninstall] operations sequentially. Operations
@@ -50,7 +47,7 @@ impl SETUP {
     /// [prepare]: Self::prepare_install
     /// [commit]: Self::commit_install
     /// [`uninstall`]: Self::uninstall
-    pub fn install(&self, config: InstallConfig, update: Option<UninstallConfig>) -> ResponseVar<Result<UninstallConfig>> {
+    pub fn install(&self, config: InstallConfig, update: Option<UninstallConfig>) -> ResponseVar<Result<UninstallConfig, SetupError>> {
         let (r, rsp) = response_var();
         UPDATES.once_update("install", move || {
             SETUP_SV.write().run(async move { install(config, update).await }, r);
@@ -71,7 +68,11 @@ impl SETUP {
     ///
     /// [`commit_install`]: Self::commit_install
     /// [`cancel_prepared`]: Self::cancel_prepared
-    pub fn prepare_install(&self, config: InstallConfig, update: Option<UninstallConfig>) -> ResponseVar<Result<PreparedInstallConfig>> {
+    pub fn prepare_install(
+        &self,
+        config: InstallConfig,
+        update: Option<UninstallConfig>,
+    ) -> ResponseVar<Result<PreparedInstallConfig, SetupError>> {
         let (r, rsp) = response_var();
         UPDATES.once_update("prepare_install", move || {
             SETUP_SV.write().run(async move { prepare_install(config, update).await }, r);
@@ -85,7 +86,7 @@ impl SETUP {
     /// a prepared install that already completed.
     ///
     /// [`prepare_install`]: Self::prepare_install
-    pub fn cancel_prepared(&self, config: PreparedInstallConfig) -> ResponseVar<Result<()>> {
+    pub fn cancel_prepared(&self, config: PreparedInstallConfig) -> ResponseVar<Result<(), SetupError>> {
         let (r, rsp) = response_var();
         UPDATES.once_update("cancel_prepared", move || {
             SETUP_SV.write().run(async move { cancel_prepared(config).await }, r);
@@ -104,7 +105,7 @@ impl SETUP {
     ///
     /// [`cancel_prepared`]: Self::cancel_prepared
     /// [`uninstall`]: Self::uninstall
-    pub fn commit_install(&self, config: PreparedInstallConfig) -> ResponseVar<Result<UninstallConfig>> {
+    pub fn commit_install(&self, config: PreparedInstallConfig) -> ResponseVar<Result<UninstallConfig, SetupError>> {
         let (r, rsp) = response_var();
         UPDATES.once_update("commit_install", move || {
             SETUP_SV.write().run(async move { commit_install(config).await }, r);
@@ -120,7 +121,7 @@ impl SETUP {
     /// Returns a response var that updates once with the result of the operation.
     ///
     /// [validate]: Self::validate_uninstall
-    pub fn uninstall(&self, config: UninstallConfig) -> ResponseVar<Result<()>> {
+    pub fn uninstall(&self, config: UninstallConfig) -> ResponseVar<Result<(), SetupError>> {
         let (r, rsp) = response_var();
         UPDATES.once_update("uninstall", move || {
             SETUP_SV.write().run(async move { uninstall(config).await }, r);
@@ -136,7 +137,7 @@ impl SETUP {
     /// successful the config data is returned, potentially corrected if recoverable issues where found.
     ///
     /// [`uninstall`]: Self::uninstall
-    pub fn validate_uninstall(&self, config: UninstallConfig) -> ResponseVar<Result<UninstallConfig>> {
+    pub fn validate_uninstall(&self, config: UninstallConfig) -> ResponseVar<Result<UninstallConfig, SetupError>> {
         let (r, rsp) = response_var();
         UPDATES.once_update("validate_uninstall", move || {
             SETUP_SV.write().run(async move { validate_uninstall(config).await }, r);
@@ -384,7 +385,11 @@ impl SetupOpStatus {
 }
 
 impl Setup {
-    fn run<R: VarValue>(&mut self, op: impl Future<Output = Result<R>> + Send + 'static, r: ResponderVar<Result<R>>) {
+    fn run<R: VarValue>(
+        &mut self,
+        op: impl Future<Output = Result<R, SetupError>> + Send + 'static,
+        r: ResponderVar<Result<R, SetupError>>,
+    ) {
         self.run_impl(Box::pin(async move {
             let res = op.await;
             r.respond(res);
@@ -411,7 +416,7 @@ impl Setup {
         }
     }
 
-    fn task_type(&self, id: &TaskTypeId) -> crate::task::Result<SetupTaskType> {
+    fn task_type(&self, id: &TaskTypeId) -> Result<SetupTaskType, SetupTaskError> {
         for t in &self.task_types {
             if &(t.task_type_id)() == id {
                 return Ok(t.clone());
@@ -421,7 +426,7 @@ impl Setup {
     }
 }
 
-async fn install(config: InstallConfig, update: Option<UninstallConfig>) -> Result<UninstallConfig> {
+async fn install(config: InstallConfig, update: Option<UninstallConfig>) -> Result<UninstallConfig, SetupError> {
     let config = prepare_install(config, update).await?;
     if SETUP_SV.read().cancel.get() {
         cancel_prepared(config).await?;
@@ -431,7 +436,7 @@ async fn install(config: InstallConfig, update: Option<UninstallConfig>) -> Resu
     }
 }
 
-async fn prepare_install(config: InstallConfig, update: Option<UninstallConfig>) -> Result<PreparedInstallConfig> {
+async fn prepare_install(config: InstallConfig, update: Option<UninstallConfig>) -> Result<PreparedInstallConfig, SetupError> {
     let (status, cancel) = {
         let sv = SETUP_SV.read();
         (sv.status.clone(), sv.cancel.clone())
@@ -554,7 +559,7 @@ async fn prepare_install(config: InstallConfig, update: Option<UninstallConfig>)
     }
 }
 
-async fn cancel_prepared(config: PreparedInstallConfig) -> Result<()> {
+async fn cancel_prepared(config: PreparedInstallConfig) -> Result<(), SetupError> {
     let status = SETUP_SV.read().status.clone();
 
     let tasks_len = config.cfg.len();
@@ -623,7 +628,7 @@ async fn cancel_prepared(config: PreparedInstallConfig) -> Result<()> {
     }
 }
 
-async fn commit_install(config: PreparedInstallConfig) -> Result<UninstallConfig> {
+async fn commit_install(config: PreparedInstallConfig) -> Result<UninstallConfig, SetupError> {
     let status = SETUP_SV.read().status.clone();
 
     let tasks_len = config.tasks.len();
@@ -706,7 +711,7 @@ async fn commit_install(config: PreparedInstallConfig) -> Result<UninstallConfig
     }
 }
 
-async fn uninstall(config: UninstallConfig) -> Result<()> {
+async fn uninstall(config: UninstallConfig) -> Result<(), SetupError> {
     let config = validate_uninstall(config).await?;
 
     let status = SETUP_SV.read().status.clone();
@@ -779,7 +784,7 @@ async fn uninstall(config: UninstallConfig) -> Result<()> {
     }
 }
 
-async fn validate_uninstall(config: UninstallConfig) -> Result<UninstallConfig> {
+async fn validate_uninstall(config: UninstallConfig) -> Result<UninstallConfig, SetupError> {
     let (status, cancel) = {
         let sv = SETUP_SV.read();
         (sv.status.clone(), sv.cancel.clone())

--- a/crates/zng-ext-setup/src/task.rs
+++ b/crates/zng-ext-setup/src/task.rs
@@ -144,7 +144,7 @@ pub trait SetupTask: Sized {
     ///
     /// The user cannot cancel uninstallation when this step is running.
     ///
-    /// Uninstall must not fail in case a step is already completed, for example, if the task must remove a file
+    /// Uninstall is idempotent, it must not fail in case a step is already completed, for example, if the task must remove a file
     /// and it is not found, that is not an error. Task runners can retry partially run uninstall with an install data clone.
     ///
     /// Uninstall must not fail at the first error encountered, a best attempt to apply all uninstall steps must be made,

--- a/crates/zng-ext-setup/src/task.rs
+++ b/crates/zng-ext-setup/src/task.rs
@@ -105,8 +105,13 @@ pub trait SetupTask: Sized {
     /// The user cannot cancel installation when this step is running. Progress indicators will only show *indeterminate*
     /// with the expectation this step will finish quickly.
     ///
+    /// Install must not fail at the first error encountered, a best attempt to apply all install steps must be made,
+    /// errors can be aggregated on the [`InstallTaskError::error`]. The [`InstallTaskError::clean_data`] must include uninstall instructions
+    /// for all successful steps, best attempt of partial steps and any data from the previous version that was not replaced in case
+    /// it is installing an update.
+    ///
     /// [`prepare_install`]: Self::prepare_install
-    fn install(args: InstallArgs<Self>) -> impl Future<Output = Result<Self::Install, SetupTaskError>> + Send + 'static;
+    fn install(args: InstallArgs<Self>) -> impl Future<Output = Result<Self::Install, InstallTaskError<Self::Install>>> + Send + 'static;
 
     /// Cancel prepared install changes.
     ///
@@ -127,7 +132,7 @@ pub trait SetupTask: Sized {
     /// This step is not expected to take long, but if it does check the [`cancel`] flag to avoid unnecessary work.
     /// If the uninstall is canceled when another task is preparing after this one the returned data is just dropped.
     ///
-    /// This step returns a validation error or the correct install data.
+    /// This step returns a validation error or the corrected install data.
     ///
     /// [`uninstall`]: Self::uninstall
     /// [`cancel`]: ValidateUninstallArgs::cancel
@@ -138,6 +143,12 @@ pub trait SetupTask: Sized {
     /// Uninstall.
     ///
     /// The user cannot cancel uninstallation when this step is running.
+    ///
+    /// Uninstall must not fail in case a step is already completed, for example, if the task must remove a file
+    /// and it is not found, that is not an error. Task runners can retry partially run uninstall with an install data clone.
+    ///
+    /// Uninstall must not fail at the first error encountered, a best attempt to apply all uninstall steps must be made,
+    /// errors can be aggregated on the [`SetupTaskError`].
     fn uninstall(args: UninstallArgs<Self>) -> impl Future<Output = Result<(), SetupTaskError>> + Send + 'static;
 }
 
@@ -293,6 +304,50 @@ impl Error for SetupTaskError {
     }
 }
 
+/// Error in a [`SetupTask::install`] task run.
+pub struct InstallTaskError<I> {
+    /// The error.
+    pub error: SetupTaskError,
+    /// Cleanup [`SetupTask::Install`] data.
+    ///
+    /// This must contain data to uninstall the partial committed changes, if there where any. Task runners may
+    /// use this to attempt a [`SetupTask::uninstall`] to cleanup the corrupted install.
+    ///
+    /// In case the install is an [update], this must also contain all data from the previous install that has not
+    /// been invalidated by the failed install.
+    ///
+    /// If this is `None` the task runner will show that the task corrupted the install and the changes made
+    /// cannot even be uninstalled. It will also assume that the [`SetupTask::PrepareInstall`] data was not
+    /// fully cleaned before the error.
+    ///
+    /// If this is `Some` the task runner will assume the [`SetupTask::PrepareInstall`] is fully cleaned. The
+    /// task must attempt to run a *cancel* on the partial prepared data that has not committed yet, if the
+    /// error was encountered before any changes where actually committed and all prepared changes where successfully
+    /// canceled this must be set to `Some` value that represents an *empty install* that the uninstall task will
+    /// recognize and immediately return success for.
+    ///
+    /// [update]: PrepareInstallArgs::update
+    pub clean_data: Option<I>,
+}
+impl<I> fmt::Debug for InstallTaskError<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InstallTaskError")
+            .field("error", &self.error)
+            .field("clean_data.is_some()", &self.clean_data.is_some())
+            .finish()
+    }
+}
+impl<I> fmt::Display for InstallTaskError<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.error, f)
+    }
+}
+impl<I> std::error::Error for InstallTaskError<I> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
 type BoxFutResult<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'static>>;
 
 fn value_de<T: ConfigValue>(raw: RawConfigValue) -> Result<T, SetupTaskError> {
@@ -308,7 +363,7 @@ pub(crate) struct SetupTaskType {
     #[allow(clippy::type_complexity)]
     pub prepare_install:
         fn(Box<dyn Any + Send>, Option<RawConfigValue>, Var<Progress>, Var<bool>) -> BoxFutResult<RawConfigValue, SetupTaskError>,
-    pub install: fn(RawConfigValue, Var<Progress>) -> BoxFutResult<RawConfigValue, SetupTaskError>,
+    pub install: fn(RawConfigValue, Var<Progress>) -> BoxFutResult<RawConfigValue, InstallTaskError<RawConfigValue>>,
     pub cancel_install: fn(RawConfigValue, Var<Progress>) -> BoxFutResult<(), SetupTaskError>,
     pub validate_uninstall: fn(RawConfigValue, Var<Progress>, Var<bool>) -> BoxFutResult<RawConfigValue, SetupTaskError>,
     pub uninstall: fn(RawConfigValue, Var<Progress>) -> BoxFutResult<(), SetupTaskError>,
@@ -345,14 +400,31 @@ impl SetupTaskType {
             Ok(RawConfigValue::serialize(r).unwrap())
         })
     }
-    fn raw_install<T: SetupTask>(data: RawConfigValue, progress: Var<Progress>) -> BoxFutResult<RawConfigValue, SetupTaskError> {
+    fn raw_install<T: SetupTask>(
+        data: RawConfigValue,
+        progress: Var<Progress>,
+    ) -> BoxFutResult<RawConfigValue, InstallTaskError<RawConfigValue>> {
         Box::pin(async move {
             let args = InstallArgs {
-                data: value_de(data)?,
+                data: match value_de(data) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return Err(InstallTaskError {
+                            error: e,
+                            // can't cancel either without the data
+                            clean_data: None,
+                        });
+                    }
+                },
                 progress,
             };
-            let r = T::install(args).await?;
-            Ok(RawConfigValue::serialize(r).unwrap())
+            match T::install(args).await {
+                Ok(r) => Ok(RawConfigValue::serialize(r).unwrap()),
+                Err(e) => Err(InstallTaskError {
+                    error: e.error,
+                    clean_data: e.clean_data.map(|d| RawConfigValue::serialize(d).unwrap()),
+                }),
+            }
         })
     }
     fn raw_cancel_install<T: SetupTask>(data: RawConfigValue, progress: Var<Progress>) -> BoxFutResult<(), SetupTaskError> {

--- a/crates/zng-ext-setup/src/task.rs
+++ b/crates/zng-ext-setup/src/task.rs
@@ -21,9 +21,6 @@ use std::{any::Any, borrow::Cow, error::Error, fmt, io, ops, path::PathBuf, pin:
 
 use zng_ext_config::{ConfigValue, RawConfigValue};
 
-/// Result type for [`SetupTask`] steps.
-pub type Result<T> = std::result::Result<T, SetupTaskError>;
-
 /// Unique name for an install or uninstall task.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
@@ -99,7 +96,9 @@ pub trait SetupTask: Sized {
     ///
     /// [`cancel_install`]: Self::cancel_install
     /// [`cancel`]: PrepareInstallArgs::cancel
-    fn prepare_install(args: PrepareInstallArgs<Self>) -> impl Future<Output = Result<Self::PrepareInstall>> + Send + 'static;
+    fn prepare_install(
+        args: PrepareInstallArgs<Self>,
+    ) -> impl Future<Output = Result<Self::PrepareInstall, SetupTaskError>> + Send + 'static;
 
     /// Commit prepared install changes.
     ///
@@ -107,7 +106,7 @@ pub trait SetupTask: Sized {
     /// with the expectation this step will finish quickly.
     ///
     /// [`prepare_install`]: Self::prepare_install
-    fn install(args: InstallArgs<Self>) -> impl Future<Output = Result<Self::Install>> + Send + 'static;
+    fn install(args: InstallArgs<Self>) -> impl Future<Output = Result<Self::Install, SetupTaskError>> + Send + 'static;
 
     /// Cancel prepared install changes.
     ///
@@ -118,7 +117,7 @@ pub trait SetupTask: Sized {
     ///
     /// [`prepare_install`]: Self::prepare_install
     /// [`install`]: Self::install
-    fn cancel_install(args: CancelInstallArgs<Self>) -> impl Future<Output = Result<()>> + Send + 'static;
+    fn cancel_install(args: CancelInstallArgs<Self>) -> impl Future<Output = Result<(), SetupTaskError>> + Send + 'static;
 
     /// Validate the install state for uninstall.
     ///
@@ -132,12 +131,14 @@ pub trait SetupTask: Sized {
     ///
     /// [`uninstall`]: Self::uninstall
     /// [`cancel`]: ValidateUninstallArgs::cancel
-    fn validate_uninstall(args: ValidateUninstallArgs<Self>) -> impl Future<Output = Result<Self::Install>> + Send + 'static;
+    fn validate_uninstall(
+        args: ValidateUninstallArgs<Self>,
+    ) -> impl Future<Output = Result<Self::Install, SetupTaskError>> + Send + 'static;
 
     /// Uninstall.
     ///
     /// The user cannot cancel uninstallation when this step is running.
-    fn uninstall(args: UninstallArgs<Self>) -> impl Future<Output = Result<()>> + Send + 'static;
+    fn uninstall(args: UninstallArgs<Self>) -> impl Future<Output = Result<(), SetupTaskError>> + Send + 'static;
 }
 
 /// Arguments for [`SetupTask::prepare_install`]
@@ -292,9 +293,9 @@ impl Error for SetupTaskError {
     }
 }
 
-type BoxFutResult<T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'static>>;
+type BoxFutResult<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'static>>;
 
-fn value_de<T: ConfigValue>(raw: RawConfigValue) -> Result<T> {
+fn value_de<T: ConfigValue>(raw: RawConfigValue) -> Result<T, SetupTaskError> {
     match raw.deserialize() {
         Ok(r) => Ok(r),
         Err(e) => Err(SetupTaskError::CorruptedTaskData(Arc::new(e))),
@@ -305,11 +306,12 @@ fn value_de<T: ConfigValue>(raw: RawConfigValue) -> Result<T> {
 pub(crate) struct SetupTaskType {
     pub task_type_id: fn() -> TaskTypeId,
     #[allow(clippy::type_complexity)]
-    pub prepare_install: fn(Box<dyn Any + Send>, Option<RawConfigValue>, Var<Progress>, Var<bool>) -> BoxFutResult<RawConfigValue>,
-    pub install: fn(RawConfigValue, Var<Progress>) -> BoxFutResult<RawConfigValue>,
-    pub cancel_install: fn(RawConfigValue, Var<Progress>) -> BoxFutResult<()>,
-    pub validate_uninstall: fn(RawConfigValue, Var<Progress>, Var<bool>) -> BoxFutResult<RawConfigValue>,
-    pub uninstall: fn(RawConfigValue, Var<Progress>) -> BoxFutResult<()>,
+    pub prepare_install:
+        fn(Box<dyn Any + Send>, Option<RawConfigValue>, Var<Progress>, Var<bool>) -> BoxFutResult<RawConfigValue, SetupTaskError>,
+    pub install: fn(RawConfigValue, Var<Progress>) -> BoxFutResult<RawConfigValue, SetupTaskError>,
+    pub cancel_install: fn(RawConfigValue, Var<Progress>) -> BoxFutResult<(), SetupTaskError>,
+    pub validate_uninstall: fn(RawConfigValue, Var<Progress>, Var<bool>) -> BoxFutResult<RawConfigValue, SetupTaskError>,
+    pub uninstall: fn(RawConfigValue, Var<Progress>) -> BoxFutResult<(), SetupTaskError>,
 }
 impl SetupTaskType {
     /// New task instance.
@@ -328,7 +330,7 @@ impl SetupTaskType {
         update: Option<RawConfigValue>,
         progress: Var<Progress>,
         cancel: Var<bool>,
-    ) -> BoxFutResult<RawConfigValue> {
+    ) -> BoxFutResult<RawConfigValue, SetupTaskError> {
         Box::pin(async move {
             let args = PrepareInstallArgs {
                 config: *config.downcast().unwrap(),
@@ -343,7 +345,7 @@ impl SetupTaskType {
             Ok(RawConfigValue::serialize(r).unwrap())
         })
     }
-    fn raw_install<T: SetupTask>(data: RawConfigValue, progress: Var<Progress>) -> BoxFutResult<RawConfigValue> {
+    fn raw_install<T: SetupTask>(data: RawConfigValue, progress: Var<Progress>) -> BoxFutResult<RawConfigValue, SetupTaskError> {
         Box::pin(async move {
             let args = InstallArgs {
                 data: value_de(data)?,
@@ -353,7 +355,7 @@ impl SetupTaskType {
             Ok(RawConfigValue::serialize(r).unwrap())
         })
     }
-    fn raw_cancel_install<T: SetupTask>(data: RawConfigValue, progress: Var<Progress>) -> BoxFutResult<()> {
+    fn raw_cancel_install<T: SetupTask>(data: RawConfigValue, progress: Var<Progress>) -> BoxFutResult<(), SetupTaskError> {
         Box::pin(async move {
             let args = CancelInstallArgs {
                 data: value_de(data)?,
@@ -366,7 +368,7 @@ impl SetupTaskType {
         data: RawConfigValue,
         progress: Var<Progress>,
         cancel: Var<bool>,
-    ) -> BoxFutResult<RawConfigValue> {
+    ) -> BoxFutResult<RawConfigValue, SetupTaskError> {
         Box::pin(async move {
             let args = ValidateUninstallArgs {
                 data: value_de(data)?,
@@ -377,7 +379,7 @@ impl SetupTaskType {
             Ok(RawConfigValue::serialize(r).unwrap())
         })
     }
-    fn raw_uninstall<T: SetupTask>(data: RawConfigValue, progress: Var<Progress>) -> BoxFutResult<()> {
+    fn raw_uninstall<T: SetupTask>(data: RawConfigValue, progress: Var<Progress>) -> BoxFutResult<(), SetupTaskError> {
         Box::pin(async move {
             let args = UninstallArgs {
                 data: value_de(data)?,
@@ -389,7 +391,7 @@ impl SetupTaskType {
 }
 
 #[allow(unused)]
-pub(crate) fn path_utf8(p: PathBuf) -> Result<String> {
+pub(crate) fn path_utf8(p: PathBuf) -> Result<String, SetupTaskError> {
     match p.to_str() {
         Some(s) => Ok(if cfg!(windows) {
             s.replace('/', "\\")

--- a/crates/zng-ext-setup/src/task/create_shortcut.rs
+++ b/crates/zng-ext-setup/src/task/create_shortcut.rs
@@ -1,6 +1,5 @@
 #![cfg(any(windows, target_os = "linux"))]
 
-#[cfg(windows)]
 use crate::task::InstallTaskError;
 use crate::task::{escape_arg, path_utf8};
 use std::fmt::Write as _;
@@ -150,7 +149,7 @@ impl super::SetupTask for CreateShortcut {
         }
 
         let data = InstallData {
-            link_file: args.data.link_file,
+            link_file: args.data.link_file.clone(),
         };
         if let Err(e) = write(&args.data.link_file, args.data.desktop) {
             return Err(InstallTaskError {

--- a/crates/zng-ext-setup/src/task/create_shortcut.rs
+++ b/crates/zng-ext-setup/src/task/create_shortcut.rs
@@ -23,7 +23,7 @@ impl super::SetupTask for CreateShortcut {
     }
 
     #[cfg(windows)]
-    async fn prepare_install(args: super::PrepareInstallArgs<Self>) -> super::Result<Self::PrepareInstall> {
+    async fn prepare_install(args: super::PrepareInstallArgs<Self>) -> Result<Self::PrepareInstall, SetupTaskError> {
         let c = args.config;
 
         let working_dir = path_utf8(c.working_dir)?;
@@ -47,7 +47,7 @@ impl super::SetupTask for CreateShortcut {
     }
 
     #[cfg(target_os = "linux")]
-    async fn prepare_install(args: super::PrepareInstallArgs<Self>) -> super::Result<Self::PrepareInstall> {
+    async fn prepare_install(args: super::PrepareInstallArgs<Self>) -> Result<Self::PrepareInstall, SetupTaskError> {
         let c = args.config;
 
         let mut desktop = "[Desktop Entry]\nVersion=1.0\nType=Application\n".to_owned();
@@ -93,7 +93,7 @@ impl super::SetupTask for CreateShortcut {
     }
 
     #[cfg(windows)]
-    async fn install(args: super::InstallArgs<Self>) -> super::Result<Self::Install> {
+    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, SetupTaskError> {
         fn install(d: PrepareInstallData) -> Result<(), mslnk::MSLinkError> {
             let mut l = mslnk::ShellLink::new(&d.target_file)?;
 
@@ -126,7 +126,7 @@ impl super::SetupTask for CreateShortcut {
     }
 
     #[cfg(target_os = "linux")]
-    async fn install(args: super::InstallArgs<Self>) -> super::Result<Self::Install> {
+    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, SetupTaskError> {
         fn write(link_file: &PathBuf, desktop: String) -> io::Result<()> {
             use std::io::Write as _;
             use std::os::unix::fs::PermissionsExt as _;
@@ -149,15 +149,15 @@ impl super::SetupTask for CreateShortcut {
         })
     }
 
-    async fn cancel_install(_: super::CancelInstallArgs<Self>) -> super::Result<()> {
+    async fn cancel_install(_: super::CancelInstallArgs<Self>) -> Result<(), SetupTaskError> {
         Ok(())
     }
 
-    async fn validate_uninstall(args: super::ValidateUninstallArgs<Self>) -> super::Result<Self::Install> {
+    async fn validate_uninstall(args: super::ValidateUninstallArgs<Self>) -> Result<Self::Install, SetupTaskError> {
         Ok(args.data)
     }
 
-    async fn uninstall(args: super::UninstallArgs<Self>) -> super::Result<()> {
+    async fn uninstall(args: super::UninstallArgs<Self>) -> Result<(), SetupTaskError> {
         if let Err(e) = fs::remove_file(&args.data.link_file)
             && !matches!(e.kind(), io::ErrorKind::NotFound)
         {

--- a/crates/zng-ext-setup/src/task/create_shortcut.rs
+++ b/crates/zng-ext-setup/src/task/create_shortcut.rs
@@ -1,5 +1,7 @@
 #![cfg(any(windows, target_os = "linux"))]
 
+#[cfg(windows)]
+use crate::task::InstallTaskError;
 use crate::task::{escape_arg, path_utf8};
 use std::fmt::Write as _;
 use std::{fs, io, path::PathBuf};
@@ -93,7 +95,7 @@ impl super::SetupTask for CreateShortcut {
     }
 
     #[cfg(windows)]
-    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, SetupTaskError> {
+    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, InstallTaskError<Self::Install>> {
         fn install(d: PrepareInstallData) -> Result<(), mslnk::MSLinkError> {
             let mut l = mslnk::ShellLink::new(&d.target_file)?;
 
@@ -116,17 +118,23 @@ impl super::SetupTask for CreateShortcut {
             l.create_lnk(d.link_file)
         }
 
-        let link_file = args.data.link_file.clone();
+        let data = InstallData {
+            link_file: args.data.link_file.clone(),
+        };
 
         if let Err(e) = install(args.data) {
-            return Err(SetupTaskError::other(e));
+            return Err(InstallTaskError {
+                error: SetupTaskError::other(e),
+                // link_file probably does not exist, but `Some` here indicates that the failed uninstall can
+                // be cleanup and `uninstall` will not error if the link file does not exist.
+                clean_data: Some(data),
+            });
         }
-
-        Ok(InstallData { link_file })
+        Ok(data)
     }
 
     #[cfg(target_os = "linux")]
-    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, SetupTaskError> {
+    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, InstallTaskError<Self::Install>> {
         fn write(link_file: &PathBuf, desktop: String) -> io::Result<()> {
             use std::io::Write as _;
             use std::os::unix::fs::PermissionsExt as _;
@@ -141,12 +149,18 @@ impl super::SetupTask for CreateShortcut {
             Ok(())
         }
 
-        if let Err(e) = write(&args.data.link_file, args.data.desktop) {
-            return Err(SetupTaskError::io(args.data.link_file, e));
-        }
-        Ok(InstallData {
+        let data = InstallData {
             link_file: args.data.link_file,
-        })
+        };
+        if let Err(e) = write(&args.data.link_file, args.data.desktop) {
+            return Err(InstallTaskError {
+                error: SetupTaskError::io(args.data.link_file, e),
+                // link_file probably does not exist, but `Some` here indicates that the failed uninstall can
+                // be cleanup and `uninstall` will not error if the link file does not exist.
+                clean_data: Some(data),
+            });
+        }
+        Ok(data)
     }
 
     async fn cancel_install(_: super::CancelInstallArgs<Self>) -> Result<(), SetupTaskError> {

--- a/crates/zng-ext-setup/src/task/extract_tar.rs
+++ b/crates/zng-ext-setup/src/task/extract_tar.rs
@@ -285,7 +285,13 @@ impl super::SetupTask for ExtractTar {
         if errors.is_empty() {
             Ok(data)
         } else {
-            // !!: TODO review if all prepared temps are clean here (see `clean_data` docs)
+            // tasks must cleanup prepared data in case of error
+            if let Err(e) = fs::remove_dir_all(&args.data.temp_dir)
+                && !matches!(e.kind(), io::ErrorKind::NotFound)
+            {
+                errors.push((args.data.temp_dir, Arc::new(e)));
+            }
+
             Err(InstallTaskError {
                 error: SetupTaskError::Io(errors),
                 clean_data: Some(data),

--- a/crates/zng-ext-setup/src/task/extract_tar.rs
+++ b/crates/zng-ext-setup/src/task/extract_tar.rs
@@ -10,7 +10,7 @@ use zng_txt::{ToTxt as _, Txt, formatx};
 use zng_unit::ByteUnits as _;
 use zng_var::{expr_var, var};
 
-use crate::task::SetupTaskError;
+use crate::task::{InstallTaskError, SetupTaskError};
 
 /// Setup task that extracts TAR container to a new or existing directory
 /// on install and removes these files on uninstall.
@@ -210,7 +210,7 @@ impl super::SetupTask for ExtractTar {
         })
     }
 
-    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, SetupTaskError> {
+    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, InstallTaskError<Self::Install>> {
         let mut errors = vec![];
 
         let mut entries = args.data.add;
@@ -275,14 +275,21 @@ impl super::SetupTask for ExtractTar {
                 errors.push((from, Arc::new(e)));
             }
         }
+
+        entries.reverse(); // uninstall removes depth first to cleanup empty dirs as it goes
+        let data = InstallData {
+            target_dir: args.data.target_dir,
+            entries,
+        };
+
         if errors.is_empty() {
-            entries.reverse(); // uninstall removes depth first to cleanup empty dirs as it goes
-            Ok(InstallData {
-                target_dir: args.data.target_dir,
-                entries,
-            })
+            Ok(data)
         } else {
-            Err(SetupTaskError::Io(errors))
+            // !!: TODO review if all prepared temps are clean here (see `clean_data` docs)
+            Err(InstallTaskError {
+                error: SetupTaskError::Io(errors),
+                clean_data: Some(data),
+            })
         }
     }
 

--- a/crates/zng-ext-setup/src/task/extract_tar.rs
+++ b/crates/zng-ext-setup/src/task/extract_tar.rs
@@ -26,7 +26,7 @@ impl super::SetupTask for ExtractTar {
         "zng-setup/ExtractTar".into()
     }
 
-    async fn prepare_install(args: super::PrepareInstallArgs<Self>) -> super::Result<Self::PrepareInstall> {
+    async fn prepare_install(args: super::PrepareInstallArgs<Self>) -> Result<Self::PrepareInstall, SetupTaskError> {
         let (parent_dir, dir_name) = match (args.config.target_dir.parent(), args.config.target_dir.file_name()) {
             (Some(p), Some(n)) if let Some(n) = n.to_str() => (p, n),
             _ => {
@@ -210,7 +210,7 @@ impl super::SetupTask for ExtractTar {
         })
     }
 
-    async fn install(args: super::InstallArgs<Self>) -> super::Result<Self::Install> {
+    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, SetupTaskError> {
         let mut errors = vec![];
 
         let mut entries = args.data.add;
@@ -286,7 +286,7 @@ impl super::SetupTask for ExtractTar {
         }
     }
 
-    async fn cancel_install(args: super::CancelInstallArgs<Self>) -> super::Result<()> {
+    async fn cancel_install(args: super::CancelInstallArgs<Self>) -> Result<(), SetupTaskError> {
         if let Err(e) = fs::remove_dir_all(&args.data.temp_dir)
             && !matches!(e.kind(), io::ErrorKind::NotFound)
         {
@@ -295,7 +295,7 @@ impl super::SetupTask for ExtractTar {
         Ok(())
     }
 
-    async fn validate_uninstall(args: super::ValidateUninstallArgs<Self>) -> super::Result<Self::Install> {
+    async fn validate_uninstall(args: super::ValidateUninstallArgs<Self>) -> Result<Self::Install, SetupTaskError> {
         let mut data = args.data;
         if !data.target_dir.exists() {
             data.entries.clear();
@@ -347,7 +347,7 @@ impl super::SetupTask for ExtractTar {
         Ok(data)
     }
 
-    async fn uninstall(args: super::UninstallArgs<Self>) -> super::Result<()> {
+    async fn uninstall(args: super::UninstallArgs<Self>) -> Result<(), SetupTaskError> {
         let mut errors = vec![];
         for entry in args.data.entries {
             let entry = args.data.target_dir.join(entry);

--- a/crates/zng-ext-setup/src/task/register_uninstaller.rs
+++ b/crates/zng-ext-setup/src/task/register_uninstaller.rs
@@ -76,7 +76,7 @@ impl super::SetupTask for RegisterUninstaller {
         "zng-setup/RegisterUninstaller".into()
     }
 
-    async fn prepare_install(args: super::PrepareInstallArgs<Self>) -> super::Result<Self::PrepareInstall> {
+    async fn prepare_install(args: super::PrepareInstallArgs<Self>) -> Result<Self::PrepareInstall, SetupTaskError> {
         let d = args.config;
 
         // validate app_id, required, no leading/trailing spaces, no '\'
@@ -128,7 +128,7 @@ impl super::SetupTask for RegisterUninstaller {
         })
     }
 
-    async fn install(args: super::InstallArgs<Self>) -> super::Result<Self::Install> {
+    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, SetupTaskError> {
         fn register(d: &PrepareInstallData) -> windows_registry::Result<()> {
             let key =
                 windows_registry::LOCAL_MACHINE.create(format!(r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{}", d.app_id))?;
@@ -155,15 +155,15 @@ impl super::SetupTask for RegisterUninstaller {
         Ok(InstallData { app_id: args.data.app_id })
     }
 
-    async fn cancel_install(_: super::CancelInstallArgs<Self>) -> super::Result<()> {
+    async fn cancel_install(_: super::CancelInstallArgs<Self>) -> Result<(), SetupTaskError> {
         Ok(())
     }
 
-    async fn validate_uninstall(args: super::ValidateUninstallArgs<Self>) -> super::Result<Self::Install> {
+    async fn validate_uninstall(args: super::ValidateUninstallArgs<Self>) -> Result<Self::Install, SetupTaskError> {
         Ok(args.data)
     }
 
-    async fn uninstall(args: super::UninstallArgs<Self>) -> super::Result<()> {
+    async fn uninstall(args: super::UninstallArgs<Self>) -> Result<(), SetupTaskError> {
         const ERROR_FILE_NOT_FOUND: i32 = 2;
         let key = format!(r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{}", args.data.app_id);
         if let Err(e) = windows_registry::LOCAL_MACHINE.remove_tree(&key)

--- a/crates/zng-ext-setup/src/task/register_uninstaller.rs
+++ b/crates/zng-ext-setup/src/task/register_uninstaller.rs
@@ -5,7 +5,7 @@ use std::{fmt, path::PathBuf};
 
 use zng_unit::ByteLength;
 
-use crate::task::{SetupTaskError, escape_arg, path_utf8};
+use crate::task::{InstallTaskError, SetupTaskError, escape_arg, path_utf8};
 
 /// Setup task that register an uninstaller for the app on Windows.
 pub enum RegisterUninstaller {}
@@ -79,6 +79,11 @@ impl super::SetupTask for RegisterUninstaller {
     async fn prepare_install(args: super::PrepareInstallArgs<Self>) -> Result<Self::PrepareInstall, SetupTaskError> {
         let d = args.config;
 
+        if let Some(u) = args.update {
+            // !!: TODO remove previous if ID changed?
+            let _ = u;
+        }
+
         // validate app_id, required, no leading/trailing spaces, no '\'
         let app_id = d.app_id.trim();
         if app_id.is_empty() || app_id.len() != d.app_id.len() || app_id.contains('\\') {
@@ -128,7 +133,7 @@ impl super::SetupTask for RegisterUninstaller {
         })
     }
 
-    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, SetupTaskError> {
+    async fn install(args: super::InstallArgs<Self>) -> Result<Self::Install, InstallTaskError<Self::Install>> {
         fn register(d: &PrepareInstallData) -> windows_registry::Result<()> {
             let key =
                 windows_registry::LOCAL_MACHINE.create(format!(r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{}", d.app_id))?;
@@ -149,10 +154,19 @@ impl super::SetupTask for RegisterUninstaller {
             Ok(())
         }
 
+        let data = InstallData {
+            app_id: args.data.app_id.clone(),
+        };
         if let Err(e) = register(&args.data) {
-            return Err(SetupTaskError::other(e));
+            return Err(InstallTaskError {
+                error: SetupTaskError::other(e),
+                // key might not actually exist, but this indicates that
+                // the failed install can be uninstalled and `uninstall` does not error
+                // if the key is not found.
+                clean_data: Some(data),
+            });
         }
-        Ok(InstallData { app_id: args.data.app_id })
+        Ok(data)
     }
 
     async fn cancel_install(_: super::CancelInstallArgs<Self>) -> Result<(), SetupTaskError> {


### PR DESCRIPTION
This change enables tasks and operations to return partial install data that can be used for best effort uninstall in case of corrupting error.

The error types have been refactored to more clearly indicate the state an operation is in after it failed.

Task docs now explicitly require that tasks must not early return in case of error.