### PR TITLE
Implement direct support fot context vars as `l10n!` args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Implement direct support fot context vars as `l10n!` args. 
+
 * Add glob tar builder tool for `cargo zng res`.
     - Adds `.zr-tar`.
     - See `cargo zng res --tool tar` for features.

--- a/crates/zng-ext-l10n-proc-macros/src/l10n.rs
+++ b/crates/zng-ext-l10n-proc-macros/src/l10n.rs
@@ -98,7 +98,7 @@ pub fn expand(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             build.extend(quote_spanned! {span=>
                 .l10n_arg(#var, {
                     use #l10n_path::IntoL10nVar;
-                    (&mut &mut &mut #l10n_path::L10nSpecialize(Some(#var_ident))).to_l10n_var()
+                    (&mut &mut &mut &mut #l10n_path::L10nSpecialize(Some(#var_ident))).to_l10n_var()
                 })
             });
         }

--- a/crates/zng-ext-l10n/src/types.rs
+++ b/crates/zng-ext-l10n/src/types.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use zng_ext_fs_watcher::WatcherReadStatus;
 use zng_layout::context::LayoutDirection;
 use zng_txt::{ToTxt, Txt};
-use zng_var::{ArcEq, IntoVar, Var, VarValue, const_var, context_var, impl_from_and_into_var};
+use zng_var::{ArcEq, ContextVar, IntoVar, Var, VarValue, const_var, context_var, impl_from_and_into_var};
 
 use crate::{L10N, lang, service::L10N_SV};
 
@@ -279,12 +279,18 @@ impl<T: Into<L10nArgument>> IntoL10nVar for &mut L10nSpecialize<T> {
         const_var(self.0.take().unwrap().into())
     }
 }
-impl<T: VarValue + Into<L10nArgument>> IntoL10nVar for &mut &mut L10nSpecialize<Var<T>> {
+
+impl<T: VarValue + Into<L10nArgument>> IntoL10nVar for &mut &mut L10nSpecialize<ContextVar<T>> {
+    fn to_l10n_var(&mut self) -> Var<L10nArgument> {
+        self.0.take().unwrap().into_var().map_into()
+    }
+}
+impl<T: VarValue + Into<L10nArgument>> IntoL10nVar for &mut &mut &mut L10nSpecialize<Var<T>> {
     fn to_l10n_var(&mut self) -> Var<L10nArgument> {
         self.0.take().unwrap().map_into()
     }
 }
-impl IntoL10nVar for &mut &mut &mut L10nSpecialize<Var<L10nArgument>> {
+impl IntoL10nVar for &mut &mut &mut &mut L10nSpecialize<Var<L10nArgument>> {
     fn to_l10n_var(&mut self) -> Var<L10nArgument> {
         self.0.take().unwrap()
     }


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->