### PR TITLE
Improve `.zr-sfx` and `.zr-tar` tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Implement direct support fot context vars as `l10n!` args. 
 
 * Add glob tar builder tool for `cargo zng res`.
-    - Adds `.zr-tar`.
+    - Adds `.zr-tar`. Produces .tar, .tar.gz or .tar.zst fully compatible with `.zr-sfx`.
     - See `cargo zng res --tool tar` for features.
 
 # 0.24.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Improve `.zr-sfx` tool.
+    - Generated executable now can now serve manifest of data entries.
+    - Now identifies files already compressed by magic number, not extension.
+
 * Implement direct support fot context vars as `l10n!` args. 
 
 * Add glob tar builder tool for `cargo zng res`.

--- a/crates/cargo-zng/src/res/built_in/sfx.rs
+++ b/crates/cargo-zng/src/res/built_in/sfx.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Write as _, io::Read};
+use std::{
+    fmt::Write as _,
+    io::{Read, Seek},
+};
 
 use indexmap::IndexMap;
 use lzma_rust2::filter::bcj::BcjWriter;
@@ -37,7 +40,7 @@ The request file:
    |
    | # data the sfx can serve the 'run'
    | [[data]]
-   | # name must be unique and not include ':', default is "", for single data
+   | # name must be unique and not include ':' or '\n', default is "", for single data
    | name = "payload"
    | # compress data on build, default is "zstd"
    | compress = "zstd"
@@ -56,7 +59,7 @@ Run:
 
 When sfx runs it extracts the 'run' executable to a temp dir and runs it.
 
-The optional 'env' variables override the system env. The SFX_ARGS and SFX_DATA var is always set. 
+The optional 'env' variables override the system env. The SFX_ARGS var is always set. 
 
 The SFX_ARGS is set to the sfx command line args, '\n' separated. The first arg is the path to the sfx exe.
 
@@ -66,6 +69,9 @@ Data:
 
 To read data the 'run' exe must spawn another instance of the sfx with the "SFX_GET_DATA" set
 to the entry name. It will serve the data to stdout. The data may be decompressed on demand.
+
+To get a list of data names and decompressed lengths run with "SFX_GET_MANIFEST", each stdout
+line is <name>:<len>, <len> is an u64 or "unknown".
 
 File Paths:
 
@@ -86,8 +92,8 @@ The sfx exe includes a zstd decompressor that is used to extract the 'run' exe.
 The decompressor code can be used to read data too. The 'compress' field values are:
 
 "none" — No compression on build. Data is served as is.
-"zstd" — Compress on build unless file extension is ".zst". Decompress on demand while reading.
-"zstd-[filter]" — Transform data to improve compression, unless file extension is ".zst". Reverses
+"zstd" — Compress on build unless file is already zstd (magic number check). Decompress on demand while reading.
+"zstd-[filter]" — Transform data to improve compression, unless file is already zstd. Reverses
   transform on demand while reading.
 
 Sfx is optimized for small number of large data entries. Use a container format to
@@ -177,17 +183,17 @@ pub(super) fn sfx() {
     }
 
     let mut data = vec![];
-    let run_compression = parse_compress(&request.sfx.rustc_target, &request.sfx.compress);
-    let run_parts = prepare_data(&tmp, 0, run_compression, &run).unwrap_or_else(|e| fatal!("cannot compress run, {e}"));
+    let mut run_compression = parse_compress(&request.sfx.rustc_target, &request.sfx.compress);
+    let run_parts = prepare_data(&tmp, 0, &mut run_compression, &run).unwrap_or_else(|e| fatal!("cannot compress run, {e}"));
     data.push((":run", run_compression, run_parts));
     for (id, d) in request.data.iter().enumerate() {
-        if d.name.contains(':') {
-            fatal!("data name cannot contain ':'");
+        if d.name.contains(':') || d.name.contains('\n') {
+            fatal!("data name cannot contain ':' or '\n'");
         }
-        let compression = parse_compress(&request.sfx.rustc_target, &d.compress);
+        let mut compression = parse_compress(&request.sfx.rustc_target, &d.compress);
         let file = d.file.as_path();
 
-        let parts = prepare_data(&tmp, id + 1, compression, file)
+        let parts = prepare_data(&tmp, id + 1, &mut compression, file)
             .unwrap_or_else(|e| fatal!("cannot process file, {e}\n    file: {}", unix_path(file)));
         data.push((d.name.as_str(), compression, parts));
     }
@@ -301,9 +307,9 @@ struct Sign {
     only_sfx: bool,
 }
 
-fn prepare_data(tmp: &Path, data_id: usize, mut compression: Compression, file: &Path) -> io::Result<Vec<PathBuf>> {
+fn prepare_data(tmp: &Path, data_id: usize, decompress: &mut Compression, file: &Path) -> io::Result<Vec<PathBuf>> {
     let file_path = file;
-    let file = fs::File::open(file)?;
+    let mut file = fs::File::open(file)?;
 
     // 200MB
     //
@@ -314,20 +320,33 @@ fn prepare_data(tmp: &Path, data_id: usize, mut compression: Compression, file: 
     // object is no longer needed as the sfx iterates over parts.
     const PART_MAX: u64 = 200u64 * 2u64.pow(20);
 
-    if let Some(ext) = file_path.extension()
-        && ext.eq_ignore_ascii_case("zst")
-    {
-        compression = Compression::None;
+    let len = file.metadata()?.len();
+    if len < 32 {
+        // not worth compressing, zstd header alone is ~18 bytes
+        *decompress = Compression::None;
     }
 
-    match compression {
+    let mut compress = *decompress;
+
+    if matches!(compress, Compression::Zstd) {
+        let mut magic = [0u8; 4];
+        file.read_exact(&mut magic)?;
+        file.seek(io::SeekFrom::Start(0))?;
+        if magic == [0x28, 0xB5, 0x2F, 0xFD] {
+            // already zstd
+            compress = Compression::None;
+        }
+    }
+
+    match compress {
         Compression::None => {
             println!("preparing {}", unix_path(file_path));
 
-            let mut len = file.metadata()?.len();
             if len <= PART_MAX {
                 return Ok(vec![file_path.to_owned()]);
             }
+
+            let mut len = len;
 
             let mut file = io::BufReader::new(file);
             let mut parts = vec![];
@@ -354,6 +373,9 @@ fn prepare_data(tmp: &Path, data_id: usize, mut compression: Compression, file: 
             // 19 is the maximum non-ultra compression
             // zstd creates an optimal BufReader
             let mut file = zstd::stream::read::Encoder::new(file, 19)?;
+
+            file.set_pledged_src_size(Some(len))?;
+            file.include_contentsize(true)?;
 
             let mut parts = vec![];
             loop {
@@ -423,6 +445,9 @@ fn prepare_data(tmp: &Path, data_id: usize, mut compression: Compression, file: 
             };
             // 22 is the maximum ultra compression (high CPU and RAM usage)
             let mut encoder = zstd::stream::write::Encoder::new(out, 22)?;
+            encoder.set_pledged_src_size(Some(len))?;
+            encoder.include_contentsize(true)?;
+
             let out = &mut encoder;
             let mut bcj_filter = match bcj {
                 BcjFilter::X86 => BcjWriter::new_x86(out, 0),

--- a/crates/cargo-zng/src/res/built_in/sfx_res/sfx_main.rs
+++ b/crates/cargo-zng/src/res/built_in/sfx_res/sfx_main.rs
@@ -48,6 +48,8 @@ pub fn main() {
 
     if let Ok(name) = std::env::var("SFX_GET_DATA") {
         return serve_data(&name);
+    } else if std::env::var("SFX_GET_MANIFEST").is_ok() {
+        return serve_manifest();
     }
     run();
 }
@@ -112,6 +114,20 @@ fn read_data(name: &str) -> Box<dyn io::Read> {
 fn serve_data(name: &str) {
     let mut data = read_data(name);
     io::copy(&mut data, &mut std::io::stdout()).unwrap_or_exit("serve_data/copy");
+}
+
+fn serve_manifest() {
+    for (name, compression, data) in DATA {
+        let len = match compression {
+            Compression::None => Some(data.iter().map(|d| d.len() as u64).sum::<u64>()),
+            Compression::Zstd | Compression::ZstdBcj(_) => zstd::zstd_safe::get_frame_content_size(data[0]).unwrap_or_default(),
+        };
+        print!("{name}:");
+        match len {
+            Some(l) => println!("{l}"),
+            None => println!("unknown"),
+        }
+    }
 }
 
 fn run() {

--- a/crates/cargo-zng/src/res/built_in/tar.rs
+++ b/crates/cargo-zng/src/res/built_in/tar.rs
@@ -53,7 +53,8 @@ The decompressor must undo these changes before reading the TAR. The .zr-sfx sup
 [zstd] — Optional ZStandard compression
 level — Compression level, -131072..=22, 0 means no compression, default is 19.
 
-Compress the TAR, after [filter] is applied, using ZStandard.
+Compress the TAR, after [filter] is applied, using ZStandard. The "contentsize" field of zstd header
+is correctly set, so this is fully compatible with .zr-sfx that uses this field to report response stream length.
 
 [gzip] — Optional GZip compression
 level — Compression level, 0..=9, 0 means no compression, default is 8.
@@ -70,19 +71,25 @@ pub(super) fn tar() {
     let target = fs::File::create(&target).unwrap_or_else(|e| fatal!("{e}"));
     let mut target: Box<dyn WriteFinish> = Box::new(target);
 
+    let tar_entries = collect_tar_entries(request.entries);
+
     if let Some(zstd) = request.zstd
         && zstd.level != 0
     {
         let range = zstd::compression_level_range();
         let level = zstd.level.clamp(*range.start(), *range.end());
-        let zstd = zstd::Encoder::new(target, level).unwrap_or_else(|e| fatal!("{e}"));
-        target = Box::new(zstd);
+        let mut encoder = zstd::Encoder::new(target, level).unwrap_or_else(|e| fatal!("{e}"));
+
+        let len = sum_tar_len(&tar_entries);
+        encoder.set_pledged_src_size(Some(len)).unwrap_or_else(|e| fatal!("{e}"));
+        encoder.include_contentsize(true).unwrap_or_else(|e| fatal!("{e}"));
+        target = Box::new(encoder);
     } else if let Some(gzip) = request.gzip
         && gzip.level != 0
     {
         let level = flate2::Compression::new(gzip.level.clamp(0, 9));
-        let gzip = flate2::write::GzEncoder::new(target, level);
-        target = Box::new(gzip);
+        let encoder = flate2::write::GzEncoder::new(target, level);
+        target = Box::new(encoder);
     }
 
     if !request.filter.bcj.is_empty() {
@@ -105,10 +112,30 @@ pub(super) fn tar() {
     // avoids some IO in the builder
     target.follow_symlinks(false);
 
-    let mut names = HashSet::new();
-    for entry in request.entries {
-        println!("{}", entry.path);
+    for entry in tar_entries {
+        println!("{}", entry.name);
+        if matches!(entry.header.entry_type(), ::tar::EntryType::Directory) {
+            const NONE: &[u8] = &[];
+            target.append(&entry.header, NONE).unwrap_or_else(|e| fatal!("{e}"));
+        } else {
+            let file = std::fs::File::open(&entry.source).unwrap_or_else(|e| fatal!("{e}"));
+            target.append(&entry.header, file).unwrap_or_else(|e| fatal!("{e}"));
+        }
+    }
 
+    target.finish().unwrap_or_else(|e| fatal!("{e}"));
+    target.into_inner().unwrap().finish().unwrap_or_else(|e| fatal!("{e}"));
+}
+
+struct TarEntry {
+    source: PathBuf,
+    name: Rc<String>,
+    header: ::tar::Header,
+}
+fn collect_tar_entries(entries: Vec<Entry>) -> Vec<TarEntry> {
+    let mut tar = Vec::with_capacity(entries.len());
+    let mut names = HashSet::new();
+    for entry in entries {
         let mut name = entry.name.as_str();
         if name.contains("/..") {
             error!("name cannot contain /..");
@@ -151,15 +178,27 @@ pub(super) fn tar() {
                     name.to_owned()
                 };
                 let name = Rc::new(name);
-                println!("   {name}");
+
+                let meta = std::fs::metadata(&glob_entry).unwrap_or_else(|e| fatal!("{e}"));
+                let mut header = ::tar::Header::new_gnu();
+                header.set_metadata(&meta);
+                if let Err(e) = header.set_path(name.as_str()) {
+                    error!("name {name:?} is not a valid TAR path, {e}");
+                    continue;
+                }
+                header.set_cksum();
 
                 if !names.insert(name.clone()) {
-                    warn!("name already defined, entry overwritten");
+                    warn!("name {name:?} already defined, entry overwritten");
+                    let i = tar.iter().position(|t: &TarEntry| t.name == name).unwrap();
+                    tar.swap_remove(i);
                 }
 
-                target
-                    .append_path_with_name(glob_entry, name.as_str())
-                    .unwrap_or_else(|e| fatal!("{e}"));
+                tar.push(TarEntry {
+                    source: glob_entry,
+                    name,
+                    header,
+                });
             } else if glob_entry.is_dir() {
                 let dir_parent = glob_entry.parent().unwrap_or_else(|| Path::new(""));
                 for dir_entry in walkdir::WalkDir::new(&glob_entry).follow_links(false) {
@@ -173,15 +212,27 @@ pub(super) fn tar() {
                             .replace('\\', "/")
                             .to_owned();
                         let name = Rc::new(name);
-                        println!("   {name}");
-                        // dirs only create a dir entry, see docs
-                        target
-                            .append_path_with_name(dir_entry, name.as_str())
-                            .unwrap_or_else(|e| fatal!("{e}"));
+
+                        let meta = std::fs::metadata(dir_entry).unwrap_or_else(|e| fatal!("{e}"));
+                        let mut header = ::tar::Header::new_gnu();
+                        header.set_metadata(&meta);
+                        if let Err(e) = header.set_path(name.as_str()) {
+                            error!("name {name:?} is not a valid TAR path, {e}");
+                            continue;
+                        }
+                        header.set_cksum();
 
                         if !names.insert(name.clone()) {
                             warn!("name already defined, entry overwritten");
+                            let i = tar.iter().position(|t: &TarEntry| t.name == name).unwrap();
+                            tar.swap_remove(i);
                         }
+
+                        tar.push(TarEntry {
+                            source: dir_entry.to_path_buf(),
+                            name,
+                            header,
+                        });
                     }
                 }
             } else {
@@ -197,9 +248,42 @@ pub(super) fn tar() {
             }
         }
     }
+    tar.sort_by(|a, b| a.name.cmp(&b.name));
+    tar
+}
 
-    target.finish().unwrap_or_else(|e| fatal!("{e}"));
-    target.into_inner().unwrap().finish().unwrap_or_else(|e| fatal!("{e}"));
+fn sum_tar_len(entries: &[TarEntry]) -> u64 {
+    struct SumWriter(u64);
+    impl io::Write for SumWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0 += buf.len() as u64;
+            Ok(buf.len())
+        }
+    
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    let mut sum = SumWriter(0);
+    {
+        let mut tar = ::tar::Builder::new(&mut sum);
+        tar.follow_symlinks(false);
+
+        for entry in entries {
+            struct LenRead(u64);
+            impl io::Read for LenRead {
+                fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                    let n = self.0.min(buf.len() as u64) as usize;
+                    buf[..n].fill(0);
+                    self.0 -= n as u64;
+                    Ok(n)
+                }
+            }
+            let len = entry.header.size().unwrap();
+            tar.append(&entry.header, LenRead(len)).unwrap();
+        }
+    }
+    sum.0
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Changes made to enable SFX clients to get the decompressed length of data.