### PR TITLE
Add `zng::task::io::Unblock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add `zng::task::io::Unblock`.
+
 * Improve `.zr-sfx` tool.
     - Generated executable now can now serve manifest of data entries.
     - Now identifies files already compressed by magic number, not extension.

--- a/crates/zng-task/src/io.rs
+++ b/crates/zng-task/src/io.rs
@@ -20,6 +20,10 @@ pub use futures_lite::io::{
     AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt, BoxedReader, BoxedWriter,
     BufReader, BufWriter, Cursor, ReadHalf, WriteHalf, copy, empty, repeat, sink, split,
 };
+
+#[doc(no_inline)]
+pub use blocking::Unblock;
+
 use parking_lot::Mutex;
 use std::io::{Error, Result};
 use zng_time::{DInstant, INSTANT};


### PR DESCRIPTION
Reexported from `blocking` crate. Very useful for declaring hybrid blocking/async IO APIs that convert in between

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->