### PR TITLE
Better `FILL` impl for `Scroll::child_align`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* `Scroll::child_align` can now also `FILL` on scrollable dimensions.
+
 * Add `zng::task::io::Unblock`.
 
 * Add `zng::setup` module.

--- a/crates/zng-wgt-scroll/src/lib.rs
+++ b/crates/zng-wgt-scroll/src/lib.rs
@@ -98,8 +98,6 @@ impl Scroll {
     widget_impl! {
         /// Content alignment when it is smaller then the viewport.
         ///
-        /// Note that [`Align::FILL`] only applies in dimensions without scrolling.
-        ///
         /// Is `CENTER` by default.
         ///
         /// [`Align::FILL`]: zng_wgt::prelude::Align::FILL

--- a/crates/zng-wgt-scroll/src/node.rs
+++ b/crates/zng-wgt-scroll/src/node.rs
@@ -64,13 +64,7 @@ pub fn viewport(child: impl IntoUiNode, mode: impl IntoVar<ScrollMode>, child_al
             }
 
             let mode = mode.get();
-            let mut child_align = child_align.get();
-            if mode.contains(ScrollMode::VERTICAL) && child_align.is_fill_y() {
-                child_align.y = 0.fct();
-            }
-            if mode.contains(ScrollMode::HORIZONTAL) && child_align.is_fill_x() {
-                child_align.x = 0.fct();
-            }
+            let child_align = child_align.get();
 
             let vp_unit = constraints.fill_size();
             let has_fill_size = !vp_unit.is_empty() && constraints.max_size() == Some(vp_unit);
@@ -107,13 +101,7 @@ pub fn viewport(child: impl IntoUiNode, mode: impl IntoVar<ScrollMode>, child_al
         }
         UiNodeOp::Layout { wl, final_size } => {
             let mode = mode.get();
-            let mut child_align = child_align.get();
-            if mode.contains(ScrollMode::VERTICAL) && child_align.is_fill_y() {
-                child_align.y = 0.fct();
-            }
-            if mode.contains(ScrollMode::HORIZONTAL) && child_align.is_fill_x() {
-                child_align.x = 0.fct();
-            }
+            let child_align = child_align.get();
 
             let constraints = LAYOUT.constraints();
             let vp_unit = constraints.fill_size();


### PR DESCRIPTION
<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->