### PR TITLE
Fix Windows build

### DIFF
--- a/crates/zng-ext-setup/Cargo.toml
+++ b/crates/zng-ext-setup/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = { version = "1.0", optional = true, default-features = false, featu
 zstd = { version = "0.14", default-features = false, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-registry = { version = "0.100", default-features = false, features = ["std"] }
+windows-registry = { version = "0.6.1", default-features = false, features = ["std"] }
 
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.62.2"


### PR DESCRIPTION
There is some conflict with dependency windows-result if we use the latest windows-registry

<!-- Please explain the changes you made, link to any relevant issue -->

<!--

Please, make sure:

- You have read the CONTRIBUTING guidelines.
- You have formatted the code using `cargo do fmt`.
- You have fixed all `cargo do check` lints.
- You have checked that all tests pass, by running `cargo do test`.
- You have tested new documentation using `cargo do doc -s -o` and all links work correctly.
- You have updated the CHANGELOG.
    - Make special note of **Breaking** changes.
    - Don't bump crate versions, just log the breaking change.

-->