### PR TITLE
Change `Var::var_eq` to now compare values in const vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Change `Var::var_eq` and `VarEq` to now compare values when both variables are const.
+
 * Add `WIZARD` contextual service.
     - Calls commands.
     - Tracks selected page.

--- a/crates/zng-var/src/var.rs
+++ b/crates/zng-var/src/var.rs
@@ -1537,9 +1537,16 @@ impl<T: VarValue> Var<T> {
 
     /// Gets if this variable is the same as `other`.
     ///
-    /// If this variable is [`SHARE`] compares the *pointer*. If this variable is local this is always `false`.
+    /// Shared variables are equal if they point to the same value and have the same capabilities.
+    /// Const variables are equal if their value is equal. Contextual variables are equal if they are
+    /// the same context variable.
     ///
-    /// [`SHARE`]: crate::VarCapability::SHARE
+    /// Use [`current_context`] to compare the variables at the caller context.
+    ///
+    /// Use [`var_instance_tag`] to compare only the shared pointers at the caller context.
+    ///
+    /// [`current_context`]: Self::current_context
+    /// [`var_instance_tag`]: AnyVar::var_instance_tag
     pub fn var_eq(&self, other: &Self) -> bool {
         self.any.var_eq(&other.any)
     }

--- a/crates/zng-var/src/var_any.rs
+++ b/crates/zng-var/src/var_any.rs
@@ -1352,9 +1352,16 @@ impl AnyVar {
 
     /// Gets if this variable is the same as `other`.
     ///
-    /// If this variable is [`SHARE`] compares the *pointer*. If this variable is local this is always `false`.
+    /// Shared variables are equal if they point to the same value and have the same capabilities.
+    /// Const variables are equal if their value is equal. Contextual variables are equal if they are
+    /// the same context variable.
     ///
-    /// [`SHARE`]: VarCapability::SHARE
+    /// Use [`current_context`] to compare the variables at the caller context.
+    ///
+    /// Use [`var_instance_tag`] to compare only the shared pointers at the caller context.
+    ///
+    /// [`current_context`]: Self::current_context
+    /// [`var_instance_tag`]: Self::var_instance_tag
     pub fn var_eq(&self, other: &AnyVar) -> bool {
         self.0.var_eq(&other.0)
     }

--- a/crates/zng-var/src/var_impl/const_var.rs
+++ b/crates/zng-var/src/var_impl/const_var.rs
@@ -76,7 +76,7 @@ impl VarImpl for ConstVar {
 
     fn var_eq(&self, other: &DynAnyVar) -> bool {
         match other {
-            DynAnyVar::Const(b) => std::ptr::eq(self, b),
+            DynAnyVar::Const(b) => self.0.eq_any(&*b.0),
             _ => false,
         }
     }


### PR DESCRIPTION
I keep expecting it to behave like this already, and forgot why it does not.